### PR TITLE
Add retries for leapp util metadata install task

### DIFF
--- a/roles/analysis/tasks/analysis-leapp.yml
+++ b/roles/analysis/tasks/analysis-leapp.yml
@@ -42,6 +42,10 @@
         remote_src: true
         owner: root
         group: root
+      register: leapp_metadata_installed
+      until: leapp_metadata_installed is not failed
+      retries: 10
+      delay: 10
 
 - name: Ensure leapp log directory exists
   ansible.builtin.file:


### PR DESCRIPTION
For occasions when the leapp utility metadata tarball download has a connection failure, implementing retries should help alleviate the task from a fatal error...
```TASK [infra.leapp.analysis : Leapp utility metadata is installed] **************
fatal: [huge-tarpon]: FAILED! => {"changed": false, "msg": "Failure downloading https://www.url.com/leapp-data-22.tar.gz, Connection failure: ('The read operation timed out',)"}