### PR TITLE
leapp_metadata_url no longer needed

### DIFF
--- a/roles/analysis/README.md
+++ b/roles/analysis/README.md
@@ -4,16 +4,11 @@ The `analysis` role is used to create the Leapp pre-upgrade report on the target
 
 The role is considered minimally invasive and hopefully will fly under the radar of your enterprise change management policy. That said, it does install the RHEL rpm packages that provide the Leapp framework if they are not already present. While application impact is very low, it may require a change ticket depending on how pedantic your policies are.
 
-## Requirements
-
-For non-CDN environments including Satellite, package metadata files needs to be provided. These files can be put on the host under the `/etc/leapp/files` directory before running the role. Alternatively, the `leapp_metadata_url` can be defined to tell the role where it can access the metadata tarball. For more information, refer to the knowledge article [Leapp utility metadata in-place upgrades of RHEL for disconnected upgrades (including Satellite)](https://access.redhat.com/articles/3664871).
-
 ## Role variables
 
 | Name                    | Default value         | Description                                         |
 |-------------------------|-----------------------|-----------------------------------------------------|
 | leapp_upgrade_type      | "satellite"           | Set to "cdn" for hosts registered with Red Hat CDN and "rhui" for hosts using rhui repos. |
-| leapp_metadata_url      |                       | See Requirements section above.                     |
 | leapp_answerfile        |                       | Optional multi-line string. If defined, this will be used as the contents of `/var/log/leapp/answerfile`. |
 | leapp_preupg_opts       |                       | Optional string to define command line options to be passed to the `leapp` command when running the pre-upgrade. |
 | post_reboot_delay       | 120                   | Optional integer to pass to the reboot post_reboot_delay option. |

--- a/roles/analysis/defaults/main.yml
+++ b/roles/analysis/defaults/main.yml
@@ -43,12 +43,6 @@ leapp_upgrade_type: satellite
 
 leapp_preupg_opts: "{{ '--no-rhsm' if leapp_upgrade_type == 'rhui' else '' }}"
 
-# leapp_metadata_url only used for non CDN leapp upgrades including Satellite
-# https://access.redhat.com/articles/3664871
-# Download and host the leapp-data file somewhere in the environment.
-# Note that there is a different leapp data file for RHEL 7.6 for IBM POWER 9 (little endian) or IBM Z (structure A) architectures.
-leapp_metadata_url: https://satellite.example.com/pub/leapp-data-21.tar.gz
-
 # Satellite Organization and Activation Keys are required if using Satellite to change content views
 # unless the content view already in use has all required repositories.
 # satellite_organization: Example

--- a/roles/analysis/tasks/analysis-leapp.yml
+++ b/roles/analysis/tasks/analysis-leapp.yml
@@ -24,29 +24,6 @@
     state: latest
   when: ansible_distribution_major_version|int == 8
 
-- name: Ensure leapp metadata is available for non CDN Leapp upgrades
-  when: leapp_upgrade_type != 'cdn'
-  block:
-    - name: /etc/leapp/files directory exists
-      ansible.builtin.file:
-        path: /etc/leapp/files
-        state: directory
-        owner: root
-        group: root
-        mode: '0755'
-
-    - name: Leapp utility metadata is installed
-      ansible.builtin.unarchive:
-        src: "{{ leapp_metadata_url }}"
-        dest: /etc/leapp/files
-        remote_src: true
-        owner: root
-        group: root
-      register: leapp_metadata_installed
-      until: leapp_metadata_installed is not failed
-      retries: 10
-      delay: 10
-
 - name: Ensure leapp log directory exists
   ansible.builtin.file:
     path: /var/log/leapp


### PR DESCRIPTION
Great news! The Leapp data files are now included with the latest release of the leapp-repository package, so we don't need to use `leapp_metadata_url` ever again. See also: https://access.redhat.com/articles/3664871. 