### PR TITLE
Fix for Pathing issue with analysis

### DIFF
--- a/roles/analysis/README.md
+++ b/roles/analysis/README.md
@@ -30,6 +30,7 @@ Activation keys provide a method to identify content views available from Red Ha
 | leapp_answerfile | Multi-line String |  | If defined, this s written to `/var/log/leapp/answerfile` before generating the pre-upgrade report. |
 | leapp_preupg_opts | String | | Optional string to define command line options to be passed to the `leapp` command when running the pre-upgrade. |
 | post_reboot_delay | Int | 120 | Optional integer to pass to the reboot post_reboot_delay option. |
+| os_path | String | Option string to override the $PATH variable used on the target node |
 
 ## Example playbook
 

--- a/roles/analysis/defaults/main.yml
+++ b/roles/analysis/defaults/main.yml
@@ -55,4 +55,5 @@ leapp_repos_enabled: []
 
 post_reboot_delay: 120
 
+os_path: $PATH
 ...

--- a/roles/analysis/tasks/analysis-leapp.yml
+++ b/roles/analysis/tasks/analysis-leapp.yml
@@ -43,6 +43,7 @@
 
 - name: Leapp preupgrade report
   ansible.builtin.shell: >
+    export PATH={{ os_path }}
     set -o pipefail;
     leapp preupgrade
     {{ leapp_preupg_opts }}


### PR DESCRIPTION
- Added default variable "os_path"
- Added extra parameter to the leapp analysis shell command to override or add to the default $PATH on the target node