### PR TITLE
Configure async/poll values via default vars

### DIFF
--- a/changelogs/fragments/async-timer-vars.yml
+++ b/changelogs/fragments/async-timer-vars.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Add the default variables async_timeout_maximum and async_poll_interval which configure the timeout and polling values resepectively for asynchronous task execution.
+    - Setting async/poll values as default vars will allow override timer values based on the end user's particular needs.
+...

--- a/roles/analysis/README.md
+++ b/roles/analysis/README.md
@@ -31,7 +31,8 @@ Activation keys provide a method to identify content views available from Red Ha
 | leapp_preupg_opts | String | | Optional string to define command line options to be passed to the `leapp` command when running the pre-upgrade. |
 | post_reboot_delay | Int | 120 | Optional integer to pass to the reboot post_reboot_delay option. |
 | os_path | String | Option string to override the $PATH variable used on the target node |
-
+| async_timeout_maximum   | Int | 7200                  | Variable used to set the asynchronous task timeout value (in seconds)
+| async_poll_interval     | Int | 60                    | Variable used to set the asynchronous task polling internal value (in seconds)
 ## Example playbook
 
 See [`analysis.yml`](../../playbooks/analysis.yml)

--- a/roles/analysis/defaults/main.yml
+++ b/roles/analysis/defaults/main.yml
@@ -56,4 +56,7 @@ leapp_repos_enabled: []
 post_reboot_delay: 120
 
 os_path: $PATH
+
+async_timeout_maximum: 7200
+async_poll_interval: 60
 ...

--- a/roles/analysis/tasks/analysis-leapp.yml
+++ b/roles/analysis/tasks/analysis-leapp.yml
@@ -52,8 +52,8 @@
   register: leapp
   args:
     executable: /bin/bash
-  async: 43200
-  poll: 60
+  async: "{{ async_timeout_maximum | int }}"
+  poll: "{{ async_poll_interval | int }}"
   failed_when: "'report has been generated' not in leapp.stdout"
 
 - name: Include check-results-file.yml

--- a/roles/analysis/tasks/analysis-preupg.yml
+++ b/roles/analysis/tasks/analysis-preupg.yml
@@ -57,8 +57,8 @@
   register: preupg
   args:
     executable: /bin/bash
-  async: 43200
-  poll: 60
+  async: "{{ async_timeout_maximum | int }}"
+  poll: "{{ async_poll_interval | int }}"
   failed_when: false
 
 - name: Assert that preupg did not encounter errors

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -17,6 +17,8 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 | post_reboot_delay       | 120                   | Optional integer to pass to the reboot post_reboot_delay option. |
 | update_grub_to_grub_2   | false                 | Boolean to control whether grub gets upgraded to grub 2 in post RHEL 6 to 7 upgrade. |
 | os_path                 | $PATH                 | Variable used to override the default $PATH environmental variable on the target node
+| async_timeout_maximum   | 7200                  | Variable used to set the asynchronous task timeout value (in seconds)
+| async_poll_interval     | 60                    | Variable used to set the asynchronous task polling internal value (in seconds)
 
 ## Example playbook
 

--- a/roles/upgrade/defaults/main.yml
+++ b/roles/upgrade/defaults/main.yml
@@ -47,4 +47,7 @@ update_grub_to_grub_2: false
 post_reboot_delay: 120
 
 os_path: $PATH
+
+async_timeout_maximum: 7200
+async_poll_interval: 60
 ...

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -32,8 +32,8 @@
     2>&1 | tee -a {{ log_file }}
   args:
     executable: /bin/bash
-  async: 43200
-  poll: 60
+  async: "{{ async_timeout_maximum | int }}"
+  poll: "{{ async_poll_interval | int }}"
 
 - name: Reboot to continue Leapp OS upgrade
   ansible.builtin.reboot:

--- a/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
@@ -58,8 +58,8 @@
   register: redhat_upgrade_tool
   args:
     executable: /bin/bash
-  async: 43200
-  poll: 60
+  async: "{{ async_timeout_maximum | int }}"
+  poll: "{{ async_poll_interval | int }}"
   # failed_when: false
 
 - name: Reboot to continue OS upgrade

--- a/roles/upgrade/tasks/update-and-reboot.yml
+++ b/roles/upgrade/tasks/update-and-reboot.yml
@@ -4,8 +4,8 @@
     name: '*'
     state: latest
   register: updates_available
-  async: 7200
-  poll: 30
+  async: "{{ async_timeout_maximum | int }}"
+  poll: "{{ async_poll_interval | int }}"
 
 - name: Reboot when updates applied
   ansible.builtin.reboot:


### PR DESCRIPTION
Setting async/poll values as default vars will allow override timer values based on the end user's particular needs.