### PR TITLE
WIP: DO NOT MERGE - redhat.rhel_system_roles instead of fedora.linux_system_roles.

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -28,6 +28,6 @@ build_ignore:
   - changelogs/.plugin-cache.yaml
 dependencies:
   "ansible.posix": ">=1.5.1"
-  "fedora.linux_system_roles": '>=1.21.0'
+  "redhat.rhel_system_roles": '>=1.22.0'
   "community.general": '>=6.6.0'
 ...

--- a/roles/upgrade/tasks/leapp-post-upgrade-crypto.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade-crypto.yml
@@ -1,7 +1,7 @@
 ---
 - name: Include rhel_system_roles.crypto_policies role
   ansible.builtin.include_role:
-    name: fedora.linux_system_roles.crypto_policies
+    name: redhat.rhel_system_roles.crypto_policies
   vars:
     crypto_policies_policy: "{{ crypto_policy }}"
 ...


### PR DESCRIPTION
I tested these changes to use redhat.rhel_system_roles instead of fedora.linux_system_roles.  We would want to use redhat.rhel_system_roles for the collection on console.redhat.com (Automation Hub) but would not want to use these changes on galaxy.ansible.com (Galaxy).

Tested OK RHEL 6-7, 7-8, and 8-9.