### PR TITLE
Fix Post-Upgrade Kernel Validation on Ansible 2.14+

### DIFF
--- a/roles/upgrade/tasks/upgrade-validation.yml
+++ b/roles/upgrade/tasks/upgrade-validation.yml
@@ -5,7 +5,6 @@
 - name: Determine rhel_dest_major_version
   ansible.builtin.set_fact:
     rhel_dest_major_version: "{{ ((ansible_facts.ansible_local.pre_ripu.distribution_major_version | int) + 1) | string }}"
-    rhel_dest_kernel_check: "el{{ ((ansible_facts.ansible_local.pre_ripu.distribution_major_version | int) + 1) | string }}"
 
 - name: Validate current OS major version
   ansible.builtin.assert:
@@ -16,6 +15,7 @@
 - name: Validate running kernel matches OS version
   ansible.builtin.assert:
     that: rhel_dest_kernel_check in ansible_kernel
+    that: "'el' ~ rhel_dest_major_version in ansible_kernel"
     fail_msg: Kernel version {{ ansible_kernel }} does not match expected OS major version el{{ rhel_dest_major_version }}.
     success_msg: Current kernel version is {{ ansible_kernel }}.
 

--- a/roles/upgrade/tasks/upgrade-validation.yml
+++ b/roles/upgrade/tasks/upgrade-validation.yml
@@ -5,6 +5,7 @@
 - name: Determine rhel_dest_major_version
   ansible.builtin.set_fact:
     rhel_dest_major_version: "{{ ((ansible_facts.ansible_local.pre_ripu.distribution_major_version | int) + 1) | string }}"
+    rhel_dest_kernel_check: "el{{ ((ansible_facts.ansible_local.pre_ripu.distribution_major_version | int) + 1) | string }}"
 
 - name: Validate current OS major version
   ansible.builtin.assert:
@@ -14,7 +15,7 @@
 
 - name: Validate running kernel matches OS version
   ansible.builtin.assert:
-    that: "'el{{ rhel_dest_major_version }}' in ansible_kernel"
+    that: rhel_dest_kernel_check in ansible_kernel
     fail_msg: Kernel version {{ ansible_kernel }} does not match expected OS major version el{{ rhel_dest_major_version }}.
     success_msg: Current kernel version is {{ ansible_kernel }}.
 

--- a/roles/upgrade/tasks/upgrade-validation.yml
+++ b/roles/upgrade/tasks/upgrade-validation.yml
@@ -14,7 +14,6 @@
 
 - name: Validate running kernel matches OS version
   ansible.builtin.assert:
-    that: rhel_dest_kernel_check in ansible_kernel
     that: "'el' ~ rhel_dest_major_version in ansible_kernel"
     fail_msg: Kernel version {{ ansible_kernel }} does not match expected OS major version el{{ rhel_dest_major_version }}.
     success_msg: Current kernel version is {{ ansible_kernel }}.


### PR DESCRIPTION
When I upgrade a host, it fails during post-upgrade tasks with the following error:

    TASK [infra.leapp.upgrade : Validate running kernel matches OS version] ********
    fatal: [host01.example.org]: FAILED! => {"msg": "The conditional check ''el8' in ansible_kernel' failed. The error was: Conditional is marked as unsafe, and cannot be evaluated."}


I believe the issue stems from a vulnerability fix introduced in Ansible 2.14.12 (first bullet under Playbook section):
https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_core_2.14.html#playbook

Wasn't sure if a new task was warranted as the workaround was to do another set_fact including the 'el' string.