### PR TITLE
Allow leapp packages to be removed

### DIFF
--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -41,6 +41,9 @@
 - name: Include check-for-old-packages.yml
   ansible.builtin.include_tasks: check-for-old-packages.yml
 
+- name: Delete exclude line from dnf.conf
+  ansible.builtin.command: "/bin/dnf config-manager --save --setopt exclude=''"
+
 - name: Remove leapp related packages
   ansible.builtin.package:
     name:


### PR DESCRIPTION
Leapp packages that were installed with the Leapp utility are automatically added to the exclude list to prevent critical files from being removed 

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/performing-post-upgrade-tasks-rhel-7-to-rhel-8_upgrading-from-rhel-7-to-rhel-8#doc-wrapper