### PR TITLE
Fix analysis handler for registering to pre-leapp activation key.

### DIFF
--- a/changelogs/fragments/fix_sat_reg_handler_pre_leapp.yml
+++ b/changelogs/fragments/fix_sat_reg_handler_pre_leapp.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Fix analysis handler for Satellite registration (add conditional for if pre_leapp key is defined).
+...

--- a/roles/analysis/handlers/main.yml
+++ b/roles/analysis/handlers/main.yml
@@ -6,6 +6,10 @@
     activationkey: "{{ satellite_activation_key_pre_leapp }}"
     org_id: "{{ satellite_organization }}"
     force_register: true
+  when:
+    - leapp_upgrade_type == 'satellite'
+    - satellite_organization is defined
+    - satellite_activation_key_pre_leapp is defined
 
 # TODO: Having issues with community.general.redhat_subscription and subscription-manager on RHEL 6.
 - name: Register to pre leapp activation key RHEL 6


### PR DESCRIPTION
Was missing conditional and would error if satellite_activation_key_leapp is provided and not satellite_activation_key_pre_leapp.