### PR TITLE
Add option to unload kernel modules before running leapp upgrade.

### DIFF
--- a/changelogs/fragments/kernel_modules_unload.yml
+++ b/changelogs/fragments/kernel_modules_unload.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add option to unload kernel modules prior to running leapp upgrade (kernel_modules_to_unload_before_upgrade).
+...

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -21,6 +21,7 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 | async_poll_interval     | 60                    | Variable used to set the asynchronous task polling internal value (in seconds)
 | check_leapp_analysis_results| true              | Allows for running remediation and going straight to upgrade without re-running analysis. |
 | post_upgrade_update     | true                   | Boolean to decide if after the upgrade is performed a dnf update will run|
+| kernel_modules_to_unload_before_upgrade | []    | A list of kernel modules to be unloaded prior to running leapp. |
 
 ## Satellite variables
 

--- a/roles/upgrade/defaults/main.yml
+++ b/roles/upgrade/defaults/main.yml
@@ -127,4 +127,5 @@ async_poll_interval: 60
 
 check_leapp_analysis_results: true
 
+kernel_modules_to_unload_before_upgrade: []
 ...

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -51,6 +51,10 @@
     "{{ repo_files_to_remove_at_upgrade }}"
   when: leapp_upgrade_type == "custom"
 
+- name: leapp-upgrade | Include rmmod_kernel_modules.yml
+  ansible.builtin.include_tasks: rmmod_kernel_modules.yml
+  loop: "{{ kernel_modules_to_unload_before_upgrade }}"
+
 - name: leapp-upgrade | Start Leapp OS upgrade
   ansible.builtin.shell: >
     set -o pipefail;

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -51,8 +51,8 @@
     "{{ repo_files_to_remove_at_upgrade }}"
   when: leapp_upgrade_type == "custom"
 
-- name: leapp-upgrade | Include rmmod_kernel_modules.yml
-  ansible.builtin.include_tasks: rmmod_kernel_modules.yml
+- name: leapp-upgrade | Include rmmod-kernel-modules.yml
+  ansible.builtin.include_tasks: rmmod-kernel-modules.yml
   loop: "{{ kernel_modules_to_unload_before_upgrade }}"
 
 - name: leapp-upgrade | Start Leapp OS upgrade

--- a/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
@@ -72,8 +72,8 @@
     state: present
   when: leapp_upgrade_type == "custom"
 
-- name: leapp-upgrade | Include rmmod_kernel_modules.yml
-  ansible.builtin.include_tasks: rmmod_kernel_modules.yml
+- name: redhat-upgrade-tool-upgrade | Include rmmod-kernel-modules.yml
+  ansible.builtin.include_tasks: rmmod-kernel-modules.yml
   loop: "{{ kernel_modules_to_unload_before_upgrade }}"
 
 # --cleanup-post removes Red Hat signed RHEL 6 packages and in theory should be safe.

--- a/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
@@ -72,6 +72,10 @@
     state: present
   when: leapp_upgrade_type == "custom"
 
+- name: leapp-upgrade | Include rmmod_kernel_modules.yml
+  ansible.builtin.include_tasks: rmmod_kernel_modules.yml
+  loop: "{{ kernel_modules_to_unload_before_upgrade }}"
+
 # --cleanup-post removes Red Hat signed RHEL 6 packages and in theory should be safe.
 - name: redhat-upgrade-tool-upgrade | Run redhat-upgrade-tool
   ansible.builtin.shell: >

--- a/roles/upgrade/tasks/rmmod-kernel-modules.yml
+++ b/roles/upgrade/tasks/rmmod-kernel-modules.yml
@@ -1,6 +1,7 @@
 ---
-- name: Unload "{{ item}}" module
+- name: rmmod-kernel-modules | Unload module {{ item }}
   community.general.modprobe:
     name: "{{ item }}"
     state: absent
 
+...

--- a/roles/upgrade/tasks/rmmod_kernel_modules.yml
+++ b/roles/upgrade/tasks/rmmod_kernel_modules.yml
@@ -1,0 +1,6 @@
+---
+- name: Unload "{{ item}}" module
+  community.general.modprobe:
+    name: "{{ item }}"
+    state: absent
+


### PR DESCRIPTION
Add kernel_modules_to_unload_before_upgrade, an empty list by default.

kernel_modules_to_unload_before_upgrade: []

Can be useful for pesky kernel modules that get reloaded mysteriously, for example pata_acpi.