### PR TITLE
remove obsolete ansible-test versions

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -198,6 +198,11 @@ jobs:
           - '3.11'
           - '3.12'
         exclude:
+          # Python 3.12 is not supported with ansible-core <= 2.15
+          - ansible: stable-2.14
+            python: '3.12'
+          - ansible: stable-2.15
+            python: '3.12'
           # Python 3.6 is not supported with ansible-core >= 2.16
           - ansible: stable-2.16
             python: '3.6'

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -185,42 +185,29 @@ jobs:
           # - stable-2.13
           - stable-2.14
           - stable-2.15
+          - stable-2.16
           - devel
         # - milestone
         python:
-          - '2.6'
           - '2.7'
-          # - '3.5'
           - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
+          - '3.12'
         exclude:
-          # Because ansible-test doesn't support Python 3.9 for Ansible 2.9
-          # and Python 3.10 is supported in 2.12 or later.
-          - ansible: stable-2.9
-            python: '3.9'
-          - ansible: stable-2.9
-            python: '3.10'
-          - ansible: stable-2.10
-            python: '3.10'
-          - ansible: stable-2.11
-            python: '3.10'
-          # Python 2.6 is not supported with ansible-core >= 2.13
-          - ansible: stable-2.13
-            python: '2.6'
-          - ansible: stable-2.14
-            python: '2.6'
-          - ansible: stable-2.15
-            python: '2.6'
-          - ansible: devel
-            python: '2.6'
-          # Upstream has removed Python 2.7 and 3.6 support
+          # Python 3.6 is not supported with ansible-core >= 2.16
+          - ansible: stable-2.16
+            python: '3.6'
+          # Python 2.7, 3.6, 3.7 not supported with upstream devel
           - ansible: devel
             python: '2.7'
           - ansible: devel
             python: '3.6'
+          - ansible: devel
+            python: '3.7'
 
 
     steps:

--- a/changelogs/fragments/fix_ci_workflow.yml
+++ b/changelogs/fragments/fix_ci_workflow.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Remove obsolete versions from CI workflow and add newer ones
+...


### PR DESCRIPTION
Trying to fix #173. 

Looks like upstream recently released ansible 2.16 and now ansible devel has dropped support for python 3.7. 