### PR TITLE
Switch ansible_python_interpreter for 7 - 8 upgrades.

### DIFF
--- a/changelogs/fragments/post_7_to_8_python_interpreter.yml
+++ b/changelogs/fragments/post_7_to_8_python_interpreter.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add variable for setting ansible_python_interpretor for RHEL 7 to 8 upgrades post upgrade post_7_to_8_python_interpreter.
+...

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -22,6 +22,8 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 | check_leapp_analysis_results| true              | Allows for running remediation and going straight to upgrade without re-running analysis. |
 | post_upgrade_update     | true                   | Boolean to decide if after the upgrade is performed a dnf update will run|
 | kernel_modules_to_unload_before_upgrade | []    | A list of kernel modules to be unloaded prior to running leapp. |
+| post_7_to_8_python_interpreter | /usr/libexec/platform-python | For RHEL 7 to 8 upgrades, /usr/bin/python is discovered but not available post upgrade. For 7 to 8 upgrades, ansible_python_interpreter is set to this value post upgrade reboot prior to reconnecting. |
+
 
 ## Satellite variables
 

--- a/roles/upgrade/defaults/main.yml
+++ b/roles/upgrade/defaults/main.yml
@@ -128,4 +128,6 @@ async_poll_interval: 60
 check_leapp_analysis_results: true
 
 kernel_modules_to_unload_before_upgrade: []
+
+post_7_to_8_python_interpreter: /usr/libexec/platform-python
 ...

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -99,9 +99,9 @@
   timeout: 43260
 
 # Ansible discovers /usr/bin/python on RHEL 7, then on RHEL 8 it is no longer available.
-- name: leapp-upgrade | Set python interpreter to /usr/bin/python3 since /usr/bin/python is no longer available
+- name: leapp-upgrade | Set python interpreter to /usr/libexec/platform-python since /usr/bin/python is no longer available
   ansible.builtin.set_fact:
-    ansible_python_interpreter: /usr/bin/python3
+    ansible_python_interpreter: /usr/libexec/platform-python
 
 - name: leapp-upgrade | Wait for leapp_resume run once service to no longer exist
   ansible.builtin.service:

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -101,7 +101,8 @@
 # Ansible discovers /usr/bin/python on RHEL 7, then on RHEL 8 it is no longer available.
 - name: leapp-upgrade | Set python interpreter to /usr/libexec/platform-python since /usr/bin/python is no longer available
   ansible.builtin.set_fact:
-    ansible_python_interpreter: /usr/libexec/platform-python
+    ansible_python_interpreter: "{{ post_7_to_8_python_interpreter }}"
+  when: ansible_distribution_major_version == "7"
 
 - name: leapp-upgrade | Wait for leapp_resume run once service to no longer exist
   ansible.builtin.service:


### PR DESCRIPTION
Switch from /usr/bin/python3 to /usr/libexec/platform-python.

May address https://github.com/redhat-cop/infra.leapp/issues/160 and doesn't change behavior.