### PR TITLE
Add reboot and upgrade timeout variables

### DIFF
--- a/changelogs/fragments/post_upgrade_update copy.yml
+++ b/changelogs/fragments/post_upgrade_update copy.yml
@@ -1,0 +1,4 @@
+---
+major_changes:
+  - Variabilize reboot_timeout and upgrade_timeout.
+...

--- a/changelogs/fragments/reboot_and_upgrade_timeoutes.yml
+++ b/changelogs/fragments/reboot_and_upgrade_timeoutes.yml
@@ -1,4 +1,4 @@
 ---
-major_changes:
+minor_changes:
   - Variabilize reboot_timeout and upgrade_timeout.
 ...

--- a/roles/analysis/README.md
+++ b/roles/analysis/README.md
@@ -39,7 +39,6 @@ See comments in defaults/main.yml for additional details.
 |-----------------------|------|-------------------------|-------------------------------------------------|
 | leapp_answerfile | Multi-line String |  | If defined, this is written to `/var/log/leapp/answerfile` before generating the pre-upgrade report. |
 | leapp_preupg_opts | String | | Optional string to define command line options to be passed to the `leapp` command when running the pre-upgrade. |
-| post_reboot_delay | Int | 120 | Optional integer to pass to the reboot post_reboot_delay option. |
 | os_path | String | $PATH | Option string to override the $PATH variable used on the target node |
 | async_timeout_maximum   | Int | 7200                  | Variable used to set the asynchronous task timeout value (in seconds)
 | async_poll_interval     | Int | 60                    | Variable used to set the asynchronous task polling internal value (in seconds)

--- a/roles/analysis/defaults/main.yml
+++ b/roles/analysis/defaults/main.yml
@@ -128,8 +128,6 @@ local_repos_post_analysis: []
 #     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
 #     # state: present # Defaults to present
 
-post_reboot_delay: 120
-
 os_path: $PATH
 
 async_timeout_maximum: 7200

--- a/roles/remediate/README.md
+++ b/roles/remediate/README.md
@@ -11,6 +11,8 @@ The `remediation` role is to assist in the remediation of a system. This role co
 | leapp_report_location   | /var/log/leapp/leapp-report.json | Location of the leapp report file.       |
 | remediation_playbooks   | see [Remediation playbooks](#remediation-playbooks) | List of available remediation playbooks.|
 | remediation_todo        | []                    | List of remediation playbooks to run.               |
+| reboot_timeout          | 7200                  | Integer for maximum seconds to wait for reboot to complete.     |
+| post_reboot_delay       | 120                   | Integer to pass to the reboot post_reboot_delay option. |
 
 `remediation_todo` is a list of remediation playbooks to run. The list is empty by default. The list can be populated by the titles from [Remediation playbooks](#remediation-playbooks) section. For example:
 

--- a/roles/remediate/defaults/main.yml
+++ b/roles/remediate/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # defaults file for remedations
 
+reboot_timeout: 7200
 post_reboot_delay: 120
 leapp_report_location: /var/log/leapp/leapp-report.json
 remediation_playbooks:

--- a/roles/remediate/tasks/leapp_multiple_kernels.yml
+++ b/roles/remediate/tasks/leapp_multiple_kernels.yml
@@ -21,9 +21,11 @@
 
     - name: leapp_multiple_kernels | Update-and-reboot | Reboot when updates applied
       ansible.builtin.reboot:
-        reboot_timeout: 7200
+        reboot_timeout: "{{ reboot_timeout }}"
         post_reboot_delay: "{{ post_reboot_delay }}"
+      timeout: "{{ reboot_timeout }}"
       when: installed_kernels.stdout_lines[0] != current_kernel.stdout
+
     - name: leapp_multiple_kernels | Remove old kernels
       ansible.builtin.yum:
         name: kernel-core-{{ item }}

--- a/roles/remediate/tasks/leapp_newest_kernel_not_in_use.yml
+++ b/roles/remediate/tasks/leapp_newest_kernel_not_in_use.yml
@@ -15,7 +15,8 @@
 
     - name: leapp_newest_kernel_not_in_use | Update-and-reboot | Reboot when updates applied
       ansible.builtin.reboot:
-        reboot_timeout: 7200
+        reboot_timeout: "{{ reboot_timeout }}"
         post_reboot_delay: "{{ post_reboot_delay }}"
+      timeout: "{{ reboot_timeout }}"
 
 ...

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -14,7 +14,9 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 | selinux_mode            | same as before upgrade | Define this variable to the desired SELinux mode to be set after the OS upgrade, i.e., enforcing, permissive, or disabled. By default, the SELinux mode will be set to what was found during the pre-upgrade analysis. |
 | set_crypto_policies     | true                  | Boolean to define if system-wide cryptographic policies should be set after the OS upgrade |
 | crypto_policy           | "DEFAULT"             | System-wide cryptographic to set, e.g., "FUTURE", "DEFAULT:SHA1", etc. Refer to the crypto-policies (7) man page for more information. |
-| post_reboot_delay       | 120                   | Optional integer to pass to the reboot post_reboot_delay option. |
+| reboot_timeout          | 7200                  | Integer for maximum seconds to wait for reboot to complete.     |
+| upgrade_timeout         | 14400                 | Integer for maximum seconds to wait for reboot to complete during upgrade reboot.     |
+| post_reboot_delay       | 120                   | Integer to pass to the reboot post_reboot_delay option. |
 | update_grub_to_grub_2   | false                 | Boolean to control whether grub gets upgraded to grub 2 in post RHEL 6 to 7 upgrade. |
 | os_path                 | $PATH                 | Variable used to override the default $PATH environmental variable on the target node
 | async_timeout_maximum   | 7200                  | Variable used to set the asynchronous task timeout value (in seconds)

--- a/roles/upgrade/defaults/main.yml
+++ b/roles/upgrade/defaults/main.yml
@@ -118,6 +118,8 @@ post_upgrade_update: true
 # /boot is on.
 # grub_boot_device: /dev/sda
 
+reboot_timeout: 7200
+upgrade_timeout: 14400
 post_reboot_delay: 120
 
 os_path: $PATH

--- a/roles/upgrade/tasks/grub2-upgrade.yml
+++ b/roles/upgrade/tasks/grub2-upgrade.yml
@@ -60,7 +60,8 @@
 
 - name: grub2-upgrade | Reboot to start using grub2
   ansible.builtin.reboot:
-    reboot_timeout: 7200
+    reboot_timeout: "{{ reboot_timeout }}"
     post_reboot_delay: "{{ post_reboot_delay }}"
+  timeout: "{{ reboot_timeout }}"
 
 ...

--- a/roles/upgrade/tasks/leapp-post-upgrade-selinux.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade-selinux.yml
@@ -16,9 +16,9 @@
 
 - name: leapp-post-upgrade-selinux | Reboot when required for SELinux change
   ansible.builtin.reboot:
-    reboot_timeout: 7200
+    reboot_timeout: "{{ reboot_timeout }}"
     post_reboot_delay: "{{ post_reboot_delay }}"
-  timeout: 7260
+  timeout: "{{ reboot_timeout }}"
   when: selinux_results.reboot_required
 
 - name: leapp-post-upgrade-selinux | Verify SELinux is set to {{ selinux_mode }}

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -94,9 +94,9 @@
 - name: leapp-upgrade | Reboot to continue Leapp OS upgrade
   ansible.builtin.reboot:
     msg: Host is starting Leapp OS upgrade now!
-    reboot_timeout: 43200
+    reboot_timeout: "{{ upgrade_timeout }}"
     post_reboot_delay: "{{ post_reboot_delay }}"
-  timeout: 43260
+  timeout: "{{ upgrade_timeout }}"
 
 # Ansible discovers /usr/bin/python on RHEL 7, then on RHEL 8 it is no longer available.
 - name: leapp-upgrade | Set python interpreter to /usr/bin/python3 since /usr/bin/python is no longer available
@@ -125,7 +125,8 @@
 
     - name: leapp-upgrade | Reboot to pickup grub update
       ansible.builtin.reboot:
-        reboot_timeout: 7200
+        reboot_timeout: "{{ reboot_timeout }}"
         post_reboot_delay: "{{ post_reboot_delay }}"
-      timeout: 7260
+      timeout: "{{ reboot_timeout }}"
+
 ...

--- a/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-upgrade.yml
@@ -94,6 +94,8 @@
 - name: redhat-upgrade-tool-upgrade | Reboot to continue OS upgrade
   ansible.builtin.reboot:
     msg: Host is starting OS upgrade now!
+    reboot_timeout: "{{ upgrade_timeout }}"
     post_reboot_delay: "{{ post_reboot_delay }}"
-    reboot_timeout: 43200
+  timeout: "{{ upgrade_timeout }}"
+
 ...

--- a/roles/upgrade/tasks/update-and-reboot.yml
+++ b/roles/upgrade/tasks/update-and-reboot.yml
@@ -9,8 +9,9 @@
 
 - name: update-and-reboot | Reboot when updates applied
   ansible.builtin.reboot:
-    reboot_timeout: 7200
+    reboot_timeout: "{{ reboot_timeout }}"
     post_reboot_delay: "{{ post_reboot_delay }}"
+  timeout: "{{ reboot_timeout }}"
   when: updates_available.changed # noqa: no-handler
 
 ...


### PR DESCRIPTION
Add task timeout to reboots without it.

Remove post_reboot_delay from analysis roll where there are no reboots.

Addresses https://github.com/redhat-cop/infra.leapp/issues/172.

