### PR TITLE
Allow providing a list of known inhibitors

### DIFF
--- a/changelogs/fragments/allow_listing_known_inhibitors.yml
+++ b/changelogs/fragments/allow_listing_known_inhibitors.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Allow listing known inhibitors for which remediations are available

--- a/roles/analysis/README.md
+++ b/roles/analysis/README.md
@@ -39,9 +39,11 @@ See comments in defaults/main.yml for additional details.
 |-----------------------|------|-------------------------|-------------------------------------------------|
 | leapp_answerfile | Multi-line String |  | If defined, this is written to `/var/log/leapp/answerfile` before generating the pre-upgrade report. |
 | leapp_preupg_opts | String | | Optional string to define command line options to be passed to the `leapp` command when running the pre-upgrade. |
+| leapp_known_inhibitors | List | [] | List of keys of known inhibitors ignored when setting upgrade_inhibited and leapp_inhibitors. |
 | os_path | String | $PATH | Option string to override the $PATH variable used on the target node |
 | async_timeout_maximum   | Int | 7200                  | Variable used to set the asynchronous task timeout value (in seconds)
 | async_poll_interval     | Int | 60                    | Variable used to set the asynchronous task polling internal value (in seconds)
+
 ## Example playbook
 
 See [`analysis.yml`](../../playbooks/analysis.yml)

--- a/roles/analysis/defaults/main.yml
+++ b/roles/analysis/defaults/main.yml
@@ -52,6 +52,10 @@ leapp_repos_enabled: []
 # leapp_repos_enabled:
 #   - satellite-client-6-for-rhel-{{ ansible_distribution_major_version | int + 1 }}-x86_64-rpms
 
+# List of keys of known inhibitors which will be excluded when setting upgrade_inhibited and leapp_inhibitors
+# This allows ignoring inhibitors for which remediations are available and require no further attention
+leapp_known_inhibitors: []
+
 # For leapp_upgrade_type == "custom"
 # Used to configure repos before running leapp analysis / installing leapp packages.
 local_repos_pre_leapp: []

--- a/roles/analysis/tasks/analysis-leapp.yml
+++ b/roles/analysis/tasks/analysis-leapp.yml
@@ -96,6 +96,8 @@
 - name: analysis-leapp | Capture inhibitors in a list leapp_inhibitors
   ansible.builtin.set_fact:
     leapp_inhibitors: "{{ leapp_inhibitors | default([]) + [item] }}"
-  when: "'inhibitor' in item.flags"
+  when:
+    - "'inhibitor' in item.flags"
+    - item.key not in leapp_known_inhibitors
   loop: "{{ leapp_report_json.entries }}"
 ...

--- a/roles/parse_leapp_report/tasks/main.yml
+++ b/roles/parse_leapp_report/tasks/main.yml
@@ -21,7 +21,9 @@
 - name: Check for inhibitors
   ansible.builtin.set_fact:
     upgrade_inhibited: true
-  when: "'inhibitor' in item.flags"
+  when:
+    - "'inhibitor' in item.flags"
+    - item.key not in leapp_known_inhibitors
   loop: "{{ leapp_report_json.entries }}"
 
 # Not all inhibitors are high.


### PR DESCRIPTION
Add a variable to allow providing a list of keys of known inhibitors, these known inhibitors will be ignored when setting leapp_inhibitors and considering the value for upgrade_inhibited.

Example usage, here VDO related inhibitors are listed as known and they will not cause the playbook to fail on any host:

```
    leapp_known_inhibitors:
      # vdo check
      - 2f9802dc91315806c7cdc3c18d7b74f2a2383285
      # vdo package
      - 429a99e13b19a7eebadbb8cb35233d8119bcf255
  tasks:
    - name: Generate preupgrade analysis report
      ansible.builtin.import_role:
        name: infra.leapp.analysis

    - name: Fail if unknown inhibitors found
      fail:
        msg: Unknown inhibitors found, see the logs for details.
      when: upgrade_inhibited
```

This is helpful when dealing with a large number of hosts and where remediations for the known inhibitors are available, for any new hosts only unknown or unhandled inhibitors would cause the playbook to fail and thus the need to investigate in detail.

Resolves #123 