### PR TITLE
increase per-process file descriptor limit

### DIFF
--- a/changelogs/fragments/fix_ulimit.yml
+++ b/changelogs/fragments/fix_ulimit.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Run leapp with increased per-process file descriptor limit
+...

--- a/roles/analysis/tasks/analysis-leapp.yml
+++ b/roles/analysis/tasks/analysis-leapp.yml
@@ -68,6 +68,7 @@
   ansible.builtin.shell: >
     set -o pipefail;
     export PATH={{ os_path }};
+    ulimit -n 16384;
     leapp preupgrade --report-schema=1.2.0
     {{ leapp_preupg_opts }}
     {{ leapp_enable_repos_args }}

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -62,6 +62,7 @@
       ansible.builtin.shell: >
         set -o pipefail;
         export PATH={{ os_path }};
+        ulimit -n 16384;
         leapp upgrade --report-schema=1.2.0
         {{ leapp_upgrade_opts }}
         {{ leapp_enable_repos_args }}


### PR DESCRIPTION
Fixes #218. 

Tested successfully in our workshop lab environment with reproducer known to trigger the issue.