### PR TITLE
Support optional gpgkey and repo_gpgcheck yum repository attributes

### DIFF
--- a/changelogs/fragments/support_gpgkey_and_repo_gpgcheck.yml
+++ b/changelogs/fragments/support_gpgkey_and_repo_gpgcheck.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Support optional gpgkey and repo_gpgcheck yum repository attributes

--- a/roles/analysis/defaults/main.yml
+++ b/roles/analysis/defaults/main.yml
@@ -69,6 +69,7 @@ local_repos_pre_leapp: []
 #     # enabled: 1 # Default 1
 #     # gpgcheck: 0 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
 #     # state: present # Defaults to present
 #   - name: rhel-server-7-rpms
@@ -77,6 +78,7 @@ local_repos_pre_leapp: []
 #     # enabled: 1 # Default 1
 #     # gpgcheck: 0 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
 #     # state: present # Defaults to present
 
@@ -91,12 +93,14 @@ local_repos_leapp: []
 #     # enabled: 1 # Default 1
 #     # gpgcheck: 0 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #   - name: rhel-8-for-x86_64-appstream-rpms
 #     description: Red Hat 8.8 App Stream
 #     baseurl: http://repo01.example.com/8.8/rhel-8-for-x86_64-baseos-rpms
 #     # enabled: 1 # Default 1
 #     # gpgcheck: 0 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 
 # For leapp_upgrade_type == "custom"
 # Used to return repos to previous state after leapp analysis if necessary.
@@ -108,6 +112,7 @@ local_repos_post_analysis: []
 #     # enabled: 1 # Default 1
 #     # gpgcheck: 0 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
 #     state: absent # Defaults to present
 #   - name: rhel-server-7-rpms
@@ -116,6 +121,7 @@ local_repos_post_analysis: []
 #     # enabled: 1 # Default 1
 #     # gpgcheck: 0 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
 #     state: absent # Defaults to present
 #   - name: rhel-server-7-rpms
@@ -124,6 +130,7 @@ local_repos_post_analysis: []
 #     # enabled: 1 # Default 1
 #     # gpgcheck: 0 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
 #     # state: present # Defaults to present
 #   - name: rhel-server-7-rpms
@@ -132,6 +139,7 @@ local_repos_post_analysis: []
 #     # enabled: 1 # Default 1
 #     # gpgcheck: 0 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
 #     # state: present # Defaults to present
 

--- a/roles/analysis/tasks/analysis-leapp.yml
+++ b/roles/analysis/tasks/analysis-leapp.yml
@@ -54,6 +54,8 @@
     baseurl: "{{ item.baseurl }}"
     enabled: "{{ item.enabled | default(1) }}"
     gpgcheck: "{{ item.gpgcheck | default(0) }}"
+    gpgkey: "{{ item.gpgkey | default(omit) }}"
+    repo_gpgcheck: "{{ item.repo_gpgcheck | default(omit) }}"
     file: /etc/leapp/files/leapp_upgrade_repositories
     state: present
     owner: root

--- a/roles/analysis/tasks/custom-local-repos.yml
+++ b/roles/analysis/tasks/custom-local-repos.yml
@@ -6,6 +6,8 @@
     baseurl: "{{ item.baseurl }}"
     enabled: "{{ item.enabled | default(1) }}"
     gpgcheck: "{{ item.gpgcheck | default(0) }}"
+    gpgkey: "{{ item.gpgkey | default(omit) }}"
+    repo_gpgcheck: "{{ item.repo_gpgcheck | default(omit) }}"
     file: "{{ item.file | default('local') }}"
     state: "{{ item.state | default('present') }}"
     owner: root

--- a/roles/upgrade/defaults/main.yml
+++ b/roles/upgrade/defaults/main.yml
@@ -29,6 +29,7 @@ local_repos_pre_leapp: []
 #     # enabled: 1 # Default 1
 #     # gpgcheck: 0 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
 #     # state: present # Defaults to present
 #   - name: rhel-server-7-rpms
@@ -37,6 +38,7 @@ local_repos_pre_leapp: []
 #     # enabled: 1 # Default 1
 #     # gpgcheck: 0 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #     # file: local # The filename to use in /etc/yum.repos.d minus the .repo, default local.
 #     # state: present # Defaults to present
 
@@ -50,6 +52,7 @@ local_repos_leapp: []
 #     # enabled: 1 # Default 1
 #     # gpgcheck: 0 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #     # Can include file in this data structure to reuse this for local_repos_post_upgrade.
 #     # file: local # Will be ignored for leapp_upgrade_repositories.repo
 #     # state: present # Defaults to present.
@@ -59,6 +62,7 @@ local_repos_leapp: []
 #     # enabled: 1 # Default 1
 #     # gpgcheck: 0 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #     # Can include file in this data structure to reuse this for local_repos_post_upgrade.
 #     # file: local # Will be ignored for leapp_upgrade_repositories.repo
 #     # state: present # Defaults to present.
@@ -82,6 +86,7 @@ local_repos_post_upgrade: []
 #     # enabled: 0 # Default 1
 #     # gpgcheck: 1 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #     # state: present # Defaults to present.
 #   - name: rhel-8-for-x86_64-appstream-rpms
 #     description: Red Hat 8 App Stream
@@ -90,6 +95,7 @@ local_repos_post_upgrade: []
 #     # enabled: 0 # Default 1
 #     # gpgcheck: 1 # Default 0
 #     # gpgkey: XXX # Default omit.
+#     # repo_gpgcheck: 0 # Default omit.
 #     # state: present # Defaults to present.
 
 # Desired selinux mode post Leapp upgrade.

--- a/roles/upgrade/tasks/custom-local-repos.yml
+++ b/roles/upgrade/tasks/custom-local-repos.yml
@@ -6,6 +6,8 @@
     baseurl: "{{ item.baseurl }}"
     enabled: "{{ item.enabled | default(1) }}"
     gpgcheck: "{{ item.gpgcheck | default(0) }}"
+    gpgkey: "{{ item.gpgkey | default(omit) }}"
+    repo_gpgcheck: "{{ item.repo_gpgcheck | default(omit) }}"
     file: "{{ item.file | default('local') }}"
     state: "{{ item.state | default('present') }}"
     owner: root

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -37,6 +37,8 @@
     baseurl: "{{ item.baseurl }}"
     enabled: "{{ item.enabled | default(1) }}"
     gpgcheck: "{{ item.gpgcheck | default(0) }}"
+    gpgkey: "{{ item.gpgkey | default(omit) }}"
+    repo_gpgcheck: "{{ item.repo_gpgcheck | default(omit) }}"
     file: /etc/leapp/files/leapp_upgrade_repositories
     owner: root
     group: root


### PR DESCRIPTION
This PR adds support for the optional `gpgkey` and `repo_gpgcheck` yum repository attributes so that they can be included in the analysis and upgrade roles.  Support for the attributes has been added with the 'omit' default, so as not to impact existing users who are not using this feature.  The attributes are passed to the `ansible.builtin.yum_repository` module at the appropriate places.