### PR TITLE
Add option to skip the update/reboot on pre-upgraded server

### DIFF
--- a/changelogs/fragments/option_to_skip_pre_upgrade_update_boot.yml
+++ b/changelogs/fragments/option_to_skip_pre_upgrade_update_boot.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add option to skip the initial update and reboot of the pre-upgraded server

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -24,6 +24,7 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 | async_timeout_maximum   | 7200                  | Variable used to set the asynchronous task timeout value (in seconds)
 | async_poll_interval     | 60                    | Variable used to set the asynchronous task polling internal value (in seconds)
 | check_leapp_analysis_results| true              | Allows for running remediation and going straight to upgrade without re-running analysis. |
+| pre_upgrade_update      | true                  | Boolean to decide if an update and reboot on the running pre-upgrade operating system will run. |
 | post_upgrade_update     | true                   | Boolean to decide if after the upgrade is performed a dnf update will run|
 | post_upgrade_unset_release| true                | Boolean used to control whether Leapp's RHSM release lock is unset.
 | post_upgrade_release    |                       | Optional string used to set a specific RHSM release lock after the Leapp upgrade, but before the final update pass.

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -31,7 +31,6 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 | kernel_modules_to_unload_before_upgrade | []    | A list of kernel modules to be unloaded prior to running leapp. |
 | post_7_to_8_python_interpreter | /usr/libexec/platform-python | For RHEL 7 to 8 upgrades, /usr/bin/python is discovered but not available post upgrade. For 7 to 8 upgrades, ansible_python_interpreter is set to this value post upgrade reboot prior to reconnecting. |
 | infra_leapp_upgrade_system_roles_collection | fedora.linux_system_roles | Can be one of:<br>- 'fedora.linux_system_roles'<br>- 'redhat.rhel_system_roles' |
-| skip_pre_upgrade_update_reboot | false          | Skip the initial update and reboot on the running pre-upgrade operating system |
 
 
 ## Satellite variables

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -30,6 +30,7 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 | kernel_modules_to_unload_before_upgrade | []    | A list of kernel modules to be unloaded prior to running leapp. |
 | post_7_to_8_python_interpreter | /usr/libexec/platform-python | For RHEL 7 to 8 upgrades, /usr/bin/python is discovered but not available post upgrade. For 7 to 8 upgrades, ansible_python_interpreter is set to this value post upgrade reboot prior to reconnecting. |
 | infra_leapp_upgrade_system_roles_collection | fedora.linux_system_roles | Can be one of:<br>- 'fedora.linux_system_roles'<br>- 'redhat.rhel_system_roles' |
+| skip_pre_upgrade_update_reboot | false          | Skip the initial update and reboot on the running pre-upgrade operating system |
 
 
 ## Satellite variables

--- a/roles/upgrade/defaults/main.yml
+++ b/roles/upgrade/defaults/main.yml
@@ -113,11 +113,9 @@ crypto_policy: DEFAULT
 # crypto_policy: FUTURE
 # crypto_policy: DEFAULT:SHA1
 
-# Whether or not to skip the pre upgrade update and reboot of the operating system
-skip_pre_upgrade_update_reboot: false
-
 # Whether or not to update from legacy grub to grub2 in post-upgrade steps from RHEL 6 -> 7.
 update_grub_to_grub_2: false
+pre_upgrade_update: true
 post_upgrade_update: true
 post_upgrade_unset_release: true
 post_upgrade_release: ""

--- a/roles/upgrade/defaults/main.yml
+++ b/roles/upgrade/defaults/main.yml
@@ -113,6 +113,9 @@ crypto_policy: DEFAULT
 # crypto_policy: FUTURE
 # crypto_policy: DEFAULT:SHA1
 
+# Whether or not to skip the pre upgrade update and reboot of the operating system
+skip_pre_upgrade_update_reboot: false
+
 # Whether or not to update from legacy grub to grub2 in post-upgrade steps from RHEL 6 -> 7.
 update_grub_to_grub_2: false
 post_upgrade_update: true

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -29,7 +29,7 @@
 
 - name: leapp-upgrade | Include update-and-reboot.yml
   ansible.builtin.include_tasks: update-and-reboot.yml
-  when: skip_pre_upgrade_update_reboot is not defined or not skip_pre_upgrade_update_reboot|bool
+  when: pre_upgrade_update | bool
 
 - name: leapp-upgrade | Create /etc/leapp/files/leapp_upgrade_repositories.repo
   ansible.builtin.yum_repository:

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -29,6 +29,7 @@
 
 - name: leapp-upgrade | Include update-and-reboot.yml
   ansible.builtin.include_tasks: update-and-reboot.yml
+  when: skip_pre_upgrade_update_reboot is not defined or not skip_pre_upgrade_update_reboot|bool
 
 - name: leapp-upgrade | Create /etc/leapp/files/leapp_upgrade_repositories.repo
   ansible.builtin.yum_repository:


### PR DESCRIPTION
As part of the upgrade role, an initial update and reboot is performed in https://github.com/redhat-cop/infra.leapp/blob/main/roles/upgrade/tasks/leapp-upgrade.yml

Whilst this is good practice, it would be useful to have the option of disabling this so that:

- Any updates that are available on the server are not automatically applied.  For example, updates from a third party repository may bring in unwanted packages (eg a new third party kernel) and result in a server that cannot be upgraded
- Later code in the playbook may fail gracefully (for example, due lack of disk space) before the upgrade is performed.  If no additional updates have been installed on the current operating system, it is easier to recover the server to the pre-upgrade state.
- The pre-upgrade update can be performed during a different change window ahead of upgrade work.  This will reduce upgrade time by not having to perform a reboot.

This initial draft is intended to not change workflows for existing users.  If the variable `skip_pre_upgrade_update_reboot` is not provided, the update and reboot will occur as it does today.