### PR TITLE
leapp-report no longer uses groups - changed to flags

### DIFF
--- a/changelogs/fragments/bugfix_leapp_flag.yaml
+++ b/changelogs/fragments/bugfix_leapp_flag.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+- groups no longer in leapp_report - changed to flags
+

--- a/roles/parse_leapp_report/tasks/main.yml
+++ b/roles/parse_leapp_report/tasks/main.yml
@@ -27,8 +27,8 @@
   when:
     - item.key not in leapp_known_inhibitors | default([], true)
     - (leapp_high_sev_as_inhibitors | default(false, true) | bool and item.severity == 'high') or
-      'inhibitor' in item.groups | default([], true) or
-      'error' in item.groups | default([], true)
+      'inhibitor' in item.flags | default([], true) or
+      'error' in item.flags | default([], true)
   loop: "{{ leapp_report_json.entries }}"
 
 - name: Collect inhibitors


### PR DESCRIPTION
results_inhibitors was not being populated due to a change in the leapp report. It no longer uses "groups" as an identifier and uses "flags" instead.