### PR TITLE
Use community.general modules instead of modprobe command 

### DIFF
--- a/changelogs/fragments/use-community.general.yml
+++ b/changelogs/fragments/use-community.general.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- Use community.general.modprobe in leapp_loaded_removed_kernel_drivers.yml remediation

--- a/roles/remediate/tasks/leapp_loaded_removed_kernel_drivers.yml
+++ b/roles/remediate/tasks/leapp_loaded_removed_kernel_drivers.yml
@@ -42,7 +42,9 @@
         var: unsupported_modules
 
     - name: leapp_loaded_removed_kernel_drivers | Unload unsupported modules
-      ansible.builtin.command: modprobe -r "{{ item }}"
+      community.generalbuiltin.modprobe:
+        name: "{{ item }}"
+        state: absent
       loop: "{{ unsupported_modules }}"
       when: unsupported_modules is defined
       changed_when: unsupported_modules is defined


### PR DESCRIPTION
Use community.general.modprobe to remove unsupported modules in roles/remediate/tasks/leapp_loaded_removed_kernel_drivers.yml