### PR TITLE
Implement post-upgrade release set/unset for RHUI

### DIFF
--- a/changelogs/fragments/unset-rhui-release.yml
+++ b/changelogs/fragments/unset-rhui-release.yml
@@ -1,0 +1,5 @@
+---
+major_changes:
+- Implement post-upgrade release version set/unset for 'RHUI' upgrade type.
+  By default, RHUI repositories are no longer version-locked after an upgrade
+  and will be updated to the latest available content.

--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -79,7 +79,25 @@
     - post_upgrade_release | length > 0
   changed_when: true
 
-# TODO: Unset rhui release.
+- name: leapp-post-upgrade | Unset release via yum variable for RHUI upgrades
+  ansible.builtin.file:
+    path: /etc/yum/vars/releasever
+    state: absent
+  when:
+    - leapp_upgrade_type == 'rhui'
+    - post_upgrade_unset_release | bool
+    - post_upgrade_release | length == 0
+
+- name: leapp-post-upgrade | Set release via yum variable for RHUI upgrades
+  ansible.builtin.copy:
+    content: "{{ post_upgrade_release }}\n"
+    dest: /etc/yum/vars/releasever
+    owner: root
+    group: root
+    mode: '0644'
+  when:
+    - leapp_upgrade_type == 'rhui'
+    - post_upgrade_release | length > 0
 
 - name: leapp-post-upgrade | "Register to post leapp activation key"
   community.general.redhat_subscription:


### PR DESCRIPTION
By default, RHUI repositories are no longer version-locked after an upgrade and will be updated to the latest available content. This behavior can be controlled using `post_upgrade_*` variables.

resolves #235 