### PR TITLE
Update post upgrade

### DIFF
--- a/changelogs/fragments/update_post_upgrade.yaml
+++ b/changelogs/fragments/update_post_upgrade.yaml
@@ -1,0 +1,5 @@
+---
+major_changes:
+  - Add removal of previous version RHEL packages as the default based upon current RHEL 8 to 9 upgrade documentation.
+  - Add update of rescue kernel if an old one is present.
+  - Add check for /boot/loader/entries for old RHEL version kernels to post upgrade to RHEL 8+.

--- a/changelogs/fragments/update_post_upgrade.yaml
+++ b/changelogs/fragments/update_post_upgrade.yaml
@@ -1,5 +1,5 @@
 ---
 major_changes:
   - Add removal of previous version RHEL packages as the default based upon current RHEL 8 to 9 upgrade documentation.
-  - Add update of rescue kernel if an old one is present.
-  - Add check for /boot/loader/entries for old RHEL version kernels to post upgrade to RHEL 8+.
+  - Add update of rescue kernel if an old one is present based upon current RHEL 7 to 8 and 8 to 9 upgrade documentation.
+  - Add check for /boot/loader/entries for old RHEL version kernels to post upgrade to RHEL 8+ based upon current RHEL 8 to 9 upgrade documentation.

--- a/roles/flush_handlers/tasks/main.yml
+++ b/roles/flush_handlers/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Force all notified handlers to run at this point, not waiting for normal sync points
+  ansible.builtin.meta: flush_handlers
+

--- a/roles/flush_handlers/tasks/main.yml
+++ b/roles/flush_handlers/tasks/main.yml
@@ -2,3 +2,4 @@
 - name: Force all notified handlers to run at this point, not waiting for normal sync points
   ansible.builtin.meta: flush_handlers
 
+...

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -31,7 +31,7 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 | kernel_modules_to_unload_before_upgrade | []    | A list of kernel modules to be unloaded prior to running leapp. |
 | post_7_to_8_python_interpreter | /usr/libexec/platform-python | For RHEL 7 to 8 upgrades, /usr/bin/python is discovered but not available post upgrade. For 7 to 8 upgrades, ansible_python_interpreter is set to this value post upgrade reboot prior to reconnecting. |
 | infra_leapp_upgrade_system_roles_collection | fedora.linux_system_roles | Can be one of:<br>- 'fedora.linux_system_roles'<br>- 'redhat.rhel_system_roles' |
-| remove_old_rhel_packages | true                 | Boolean to control whether the previous version RHEL packages should be removed. |
+| remove_old_rhel_packages | true                 | Boolean to control whether the previous version RHEL packages should be removed. Change to false to maintain behavior of infra.leapp prior to  release 1.6.0. |
 
 ## Satellite variables
 

--- a/roles/upgrade/README.md
+++ b/roles/upgrade/README.md
@@ -14,24 +14,24 @@ Additionally a list of any non-Red Hat RPM packages that were installed on the s
 | selinux_mode            | same as before upgrade | Define this variable to the desired SELinux mode to be set after the OS upgrade, i.e., enforcing, permissive, or disabled. By default, the SELinux mode will be set to what was found during the pre-upgrade analysis. |
 | set_crypto_policies     | true                  | Boolean to define if system-wide cryptographic policies should be set after the OS upgrade |
 | crypto_policy           | "DEFAULT"             | System-wide cryptographic to set, e.g., "FUTURE", "DEFAULT:SHA1", etc. Refer to the crypto-policies (7) man page for more information. |
-| reboot_timeout          | 7200                  | Integer for maximum seconds to wait for reboot to complete.     |
-| upgrade_timeout         | 14400                 | Integer for maximum seconds to wait for reboot to complete during upgrade reboot.     |
+| reboot_timeout          | 7200                  | Integer for maximum seconds to wait for reboot to complete. |
+| upgrade_timeout         | 14400                 | Integer for maximum seconds to wait for reboot to complete during upgrade reboot. |
 | post_reboot_delay       | 120                   | Integer to pass to the reboot post_reboot_delay option. |
 | leapp_resume_retries    | 360                   | Integer for maximum retries to wait for leapp_resume service no longer exists. |
 | leapp_resume_delay      | 10                    | Integer for seconds between each attempt to check leapp_resume service no longer exists. |
 | update_grub_to_grub_2   | false                 | Boolean to control whether grub gets upgraded to grub 2 in post RHEL 6 to 7 upgrade. |
-| os_path                 | $PATH                 | Variable used to override the default $PATH environmental variable on the target node
-| async_timeout_maximum   | 7200                  | Variable used to set the asynchronous task timeout value (in seconds)
-| async_poll_interval     | 60                    | Variable used to set the asynchronous task polling internal value (in seconds)
+| os_path                 | $PATH                 | Variable used to override the default $PATH environmental variable on the target node. |
+| async_timeout_maximum   | 7200                  | Variable used to set the asynchronous task timeout value (in seconds) |
+| async_poll_interval     | 60                    | Variable used to set the asynchronous task polling internal value (in seconds) |
 | check_leapp_analysis_results| true              | Allows for running remediation and going straight to upgrade without re-running analysis. |
 | pre_upgrade_update      | true                  | Boolean to decide if an update and reboot on the running pre-upgrade operating system will run. |
-| post_upgrade_update     | true                   | Boolean to decide if after the upgrade is performed a dnf update will run|
-| post_upgrade_unset_release| true                | Boolean used to control whether Leapp's RHSM release lock is unset.
-| post_upgrade_release    |                       | Optional string used to set a specific RHSM release lock after the Leapp upgrade, but before the final update pass.
+| post_upgrade_update     | true                   | Boolean to decide if after the upgrade is performed a dnf update will run. |
+| post_upgrade_unset_release| true                | Boolean used to control whether Leapp's RHSM release lock is unset. |
+| post_upgrade_release    |                       | Optional string used to set a specific RHSM release lock after the Leapp upgrade, but before the final update pass. |
 | kernel_modules_to_unload_before_upgrade | []    | A list of kernel modules to be unloaded prior to running leapp. |
 | post_7_to_8_python_interpreter | /usr/libexec/platform-python | For RHEL 7 to 8 upgrades, /usr/bin/python is discovered but not available post upgrade. For 7 to 8 upgrades, ansible_python_interpreter is set to this value post upgrade reboot prior to reconnecting. |
 | infra_leapp_upgrade_system_roles_collection | fedora.linux_system_roles | Can be one of:<br>- 'fedora.linux_system_roles'<br>- 'redhat.rhel_system_roles' |
-
+| remove_old_rhel_packages | true                 | Boolean to control whether the previous version RHEL packages should be removed. |
 
 ## Satellite variables
 
@@ -54,13 +54,14 @@ See comments in defaults/main.yml for additional details.
 | local_repos_leapp  | List of dicts   | [] | Used to configure next version repos in /etc/leapp/files/leapp_upgrade_repositories.repo.
 | local_repos_post_upgrade  | List of dicts   | [] | Used to configure next version repos post upgrade (can be set to local_repos_leapp if the same)
 | repo_files_to_remove_at_upgrade  | List   | [] | Simpler way to remove /etc/yum.repos.d files before leapp upgrade is run.
-+| leapp_env_vars | Dict | {} | Environment variables to use when running `leapp` command. See defaults/main.yml for example. |
+| leapp_env_vars | Dict | {} | Environment variables to use when running `leapp` command. See defaults/main.yml for example. |
 
 ## Example playbook
 
 See [`upgrade.yml`](https://github.com/redhat-cop/infra.leapp/tree/main/playbooks/upgrade.yml).
 
-## Authors:
+## Authors
+
 Bob Mader, Mike Savage, Jeffrey Cutter, David Danielsson, Scott Vick
 
 ## License

--- a/roles/upgrade/defaults/main.yml
+++ b/roles/upgrade/defaults/main.yml
@@ -158,4 +158,6 @@ post_7_to_8_python_interpreter: /usr/libexec/platform-python
 # - redhat.rhel_system_roles
 infra_leapp_upgrade_system_roles_collection: fedora.linux_system_roles
 
+remove_old_rhel_packages: true
+
 ...

--- a/roles/upgrade/tasks/handle-old-packages.yml
+++ b/roles/upgrade/tasks/handle-old-packages.yml
@@ -1,6 +1,6 @@
 ---
 # TODO: Use ansible facts.
-- name: check-for-old-packages | Search for old packages and packages not versioned by rhel release
+- name: handle-old-packages | Search for old packages and packages not versioned by rhel release
   ansible.builtin.shell:
     cmd: >-
       set -o pipefail;
@@ -15,23 +15,23 @@
     - unsigned_packages_post.rc != 0
     - unsigned_packages_post.stderr != ""
 
-- name: check-for-old-packages | Set a fact that lists the old packages and packages not versioned by rhel release
+- name: handle-old-packages | Set a fact that lists the old packages and packages not versioned by rhel release
   ansible.builtin.set_fact:
     unsigned_packages_post: "{{ unsigned_packages_post.stdout_lines }}"
     cacheable: true
 
-- name: check-for-old-packages | Diff the list of current un-versioned packages and the previous list of un-versioned packages and set fact for missing packages
+- name: handle-old-packages | Diff the list of current un-versioned packages and the previous list of un-versioned packages and set fact for missing packages
   ansible.builtin.set_fact:
     missing_non_rhel_packages: "{{ ansible_facts.ansible_local.non_rhel_packages | difference(unsigned_packages_post) }}"
 
-- name: check-for-old-packages | Display warning message if there are any missing non-rhel versioned packages from the pre-upgrade
+- name: handle-old-packages | Display warning message if there are any missing non-rhel versioned packages from the pre-upgrade
   ansible.builtin.debug:
     msg:
       - Warning!! There are non-rhel packages that were removed during the upgrade. Please review the list of missing packages
       - "{{ missing_non_rhel_packages }}"
   when: missing_non_rhel_packages | length >= 1
 
-- name: check-for-old-packages | Save list of missing packages for future use/review
+- name: handle-old-packages | Save list of missing packages for future use/review
   ansible.builtin.copy:
     content: "{{ missing_non_rhel_packages }}"
     dest: /etc/ansible/facts.d/missing_packages.fact
@@ -39,20 +39,28 @@
     owner: root
     group: root
 
-- name: check-for-old-packages | Display results of search for old packages and packages not versioned by rhel release
+- name: handle-old-packages | Display results of search for old packages and packages not versioned by rhel release
   ansible.builtin.debug:
     msg: "{{ unsigned_packages_post }}"
 
-- name: check-for-old-packages | Search for packages from previous os release, packages not versioned by rhel release and all dependent packages
+- name: handle-old-packages | Search for packages from previous os release, packages not versioned by rhel release and all dependent packages
   ansible.builtin.package:
     name: "{{ unsigned_packages_post }}"
     state: absent
   check_mode: true
   register: search_packages_result
 
-- name: check-for-old-packages | Display results of the search for packages from the previous os release, packages not versioned by rhel release and all dependent
+- name: handle-old-packages | Display results of the search for packages from the previous os release, packages not versioned by rhel release and all dependent
     packages
   ansible.builtin.debug:
     msg: "{{ search_packages_result.changes.removed | default(search_packages_result.results) | default([]) | regex_replace('Removed: ', '') }}"
+
+- name: handle-old-packages | Remove old RHEL packages
+  ansible.builtin.package:
+    name: "{{ unsigned_packages_post }}"
+    state: absent
+  when:
+    - remove_old_rhel_packages
+    - ansible_distribution_major_version | int >= 7
 
 ...

--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -138,6 +138,7 @@
     export PATH={{ os_path }};
     /usr/lib/kernel/install.d/51-dracut-rescue.install add "$(uname -r)" /boot "/boot/vmlinuz-$(uname -r)"
   when: __rescue_kernel_files.files | length > 0
+  changed_when: true
 
 - name: leapp-post-upgrade | Include update-and-reboot.yml
   ansible.builtin.include_tasks: update-and-reboot.yml

--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -41,8 +41,8 @@
         state: absent
       loop: "{{ old_kernels.files }}"
 
-- name: leapp-post-upgrade | Include check-for-old-packages.yml
-  ansible.builtin.include_tasks: check-for-old-packages.yml
+- name: leapp-post-upgrade | Include handle-old-packages.yml
+  ansible.builtin.include_tasks: handle-old-packages.yml
 
 - name: leapp-post-upgrade | Remove leapp related packages
   ansible.builtin.package:
@@ -118,6 +118,27 @@
     tasks_from: custom_local_repos
   when: leapp_upgrade_type == "custom"
 
+- name: leapp-post-upgrade | Find old rescue kernel files
+  ansible.builtin.find:
+    paths:
+      - /boot
+    patterns:
+      - vmlinuz-*rescue*
+      - initramfs-*rescue*
+  register: __rescue_kernel_files
+
+- name: leapp-post-upgrade | Remove old rescue kernel files
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ __rescue_kernel_files.files }}"
+
+- name: leapp-post-upgrade | Reinstall the rescue kernel files when old ones were found
+  ansible.builtin.shell: >
+    export PATH={{ os_path }};
+    /usr/lib/kernel/install.d/51-dracut-rescue.install add "$(uname -r)" /boot "/boot/vmlinuz-$(uname -r)"
+  when: __rescue_kernel_files.files | length > 0
+
 - name: leapp-post-upgrade | Include update-and-reboot.yml
   ansible.builtin.include_tasks: update-and-reboot.yml
   when: post_upgrade_update | bool
@@ -125,7 +146,7 @@
 # TODO: Validate RHEL OS versions again?
 
 # Only found in RHEL 7 to 8 documentation
-- name: leapp-post-upgrade |  Old kernels have been removed from the bootloader entry for RHEL 7 to 8
+- name: leapp-post-upgrade | Old kernels have been removed from the bootloader entry for RHEL 7 to 8
   ansible.builtin.shell: |
     set -o pipefail;
     export PATH={{ os_path }};
@@ -134,6 +155,21 @@
   when: ansible_facts.ansible_local.pre_ripu.distribution_major_version | int == 7
   changed_when: false
   failed_when: grubby_check.stdout != 'Old kernels are not present in the bootloader.'
+
+# Only found in RHEL 8 to 9 documentation (maybe 9 to 10).
+# This fails on RHEL 8 to 9 if old kernel packages are not removed.
+# For RHEL 7 to 8, in my testing, no RHEL 7 kernels remain after leapp.
+- name: leapp-post-upgrade | No previous RHEL kernels are present in /boot/loader/entry files
+  ansible.builtin.shell: |
+    set -o pipefail;
+    export PATH={{ os_path }};
+    grep -r ".el{{ ansible_facts.ansible_local.pre_ripu.distribution_major_version }}" "/boot/loader/entries/" || echo "Everything seems ok."
+  register: boot_loader_entries
+  when:
+    - remove_old_rhel_packages # This will fail if the old kernel packages weren't removed.
+    - ansible_facts.ansible_local.pre_ripu.distribution_major_version | int >= 8
+  changed_when: false
+  failed_when: boot_loader_entries.stdout != 'Everything seems ok.'
 
 - name: leapp-post-upgrade | Include tasks for leapp post upgrade selinux
   ansible.builtin.include_tasks: leapp-post-upgrade-selinux.yml

--- a/roles/upgrade/tasks/redhat-upgrade-tool-post-upgrade.yml
+++ b/roles/upgrade/tasks/redhat-upgrade-tool-post-upgrade.yml
@@ -28,8 +28,8 @@
     tasks_from: custom_local_repos
   when: leapp_upgrade_type == "custom"
 
-- name: redhat-upgrade-tool-post-upgrade | Include check-for-old-packages.yml
-  ansible.builtin.include_tasks: check-for-old-packages.yml
+- name: redhat-upgrade-tool-post-upgrade | Include handle-old-packages.yml
+  ansible.builtin.include_tasks: handle-old-packages.yml
 
 - name: redhat-upgrade-tool-post-upgrade | Include grub2-upgrade.yml
   ansible.builtin.include_tasks: grub2-upgrade.yml


### PR DESCRIPTION
  - Add removal of previous version RHEL packages as the default based upon current RHEL 8 to 9 upgrade documentation.
  - Add update of rescue kernel if an old one is present based upon current RHEL 7 to 8 and 8 to 9 upgrade documentation.
  - Add check for /boot/loader/entries for old RHEL version kernels to post upgrade to RHEL 8+ based upon current RHEL 8 to 9 upgrade documentation.
  - I fixed some markdown issues in the upgrade role README.md file as I was updating the documentation as well.

Addresses https://github.com/redhat-cop/infra.leapp/issues/239.