### PR TITLE
removing flush_handlers role

### DIFF
--- a/changelogs/fragments/remove-flush_handlers.yaml
+++ b/changelogs/fragments/remove-flush_handlers.yaml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - removing flush_handlers which appears to be unused role, likely it wasn't meant to be added
+...

--- a/roles/flush_handlers/tasks/main.yml
+++ b/roles/flush_handlers/tasks/main.yml
@@ -1,5 +1,0 @@
----
-- name: Force all notified handlers to run at this point, not waiting for normal sync points
-  ansible.builtin.meta: flush_handlers
-
-...


### PR DESCRIPTION
removing flush_handlers which appears to be unused role, likely it wasn't meant to be added