### PR TITLE
Add Build import to collection

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -21,6 +21,8 @@ jobs:
     uses: ansible/ansible-content-actions/.github/workflows/ansible_lint.yaml@main
   sanity:
     uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@main
+  build-import:
+    uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@main
   # unit-galaxy:
   #   uses: ansible/ansible-content-actions/.github/workflows/unit.yaml@main
   # integration:


### PR DESCRIPTION
Adds build import to the github PR workflow, this will enable you to see errors before they happen for console.redhat.com publishing. It runs the same code it runs to validate the collection.