### PR TITLE
Support for upgrading from RHEL 9 to 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The collection supports RHEL in-place upgrades for the following RHEL versions:
 - RHEL 6 to RHEL 7 (RUT)
 - RHEL 7 to RHEL 8 (Leapp)
 - RHEL 8 to RHEL 9 (Leapp)
+- RHEL 9 to RHEL 10 (Leapp)
 
 The collection may be used for the RHEL upgrade paths and minor versions supported by the indicated upgrade utilities (Leapp or RUT). Refer the to Red Hat knowledge solution article [Supported in-place upgrade paths for Red Hat Enterprise Linux](https://access.redhat.com/articles/4263361) for the latest support details.
 

--- a/changelogs/fragments/rhel_9_to_10.yml
+++ b/changelogs/fragments/rhel_9_to_10.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Introduce support for upgrading from RHEL 9 to 10.

--- a/roles/analysis/defaults/main.yml
+++ b/roles/analysis/defaults/main.yml
@@ -23,12 +23,19 @@ analysis_packages_el8:
   # TODO: only w/ rhui for aws
   # - leapp-rhui-aws
 
+analysis_packages_el9:
+  - leapp-upgrade
+
 analysis_repos_el6:
   - rhel-6-server-extras-rpms
   - rhel-6-server-optional-rpms
 
 analysis_repos_el7:
   - rhel-7-server-extras-rpms
+
+analysis_repos_el8: []
+
+analysis_repos_el9: []
 
 # If defined, leapp_answerfile will be used as the contents of /var/log/leapp/answerfile.
 # leapp_answerfile: |

--- a/roles/analysis/tasks/analysis-leapp.yml
+++ b/roles/analysis/tasks/analysis-leapp.yml
@@ -29,8 +29,16 @@
 - name: analysis-leapp | Install packages for preupgrade analysis on RHEL 8
   ansible.builtin.package:
     name: "{{ analysis_packages_el8 }}"
+    enablerepo: "{{ analysis_repos_el8 }}"
     state: latest # noqa package-latest
   when: ansible_distribution_major_version|int == 8
+
+- name: analysis-leapp | Install packages for preupgrade analysis on RHEL 9
+  ansible.builtin.package:
+    name: "{{ analysis_packages_el9 }}"
+    enablerepo: "{{ analysis_repos_el9 }}"
+    state: latest # noqa package-latest
+  when: ansible_distribution_major_version|int == 9
 
 - name: analysis-leapp | Ensure leapp log directory exists
   ansible.builtin.file:


### PR DESCRIPTION
Fixes #236. 

See discussion and testing results in the comments of the issue. It will work for all `leapp_upgrade_type` settings except `RHUI` for which Red Hat has not yet released support. I'll open a new issue for tracking that. 