### PR TITLE
Remove when clause restricting task to RHEL 7

### DIFF
--- a/changelogs/fragments/sshd_remediation.yml
+++ b/changelogs/fragments/sshd_remediation.yml
@@ -1,2 +1,2 @@
-trivial:
+minor_changes:
   - sshd_remediation - remove when condition from sshd_remediation.yml which prevents the issue where the analysis role flags an inhibitor for sshd_config during a RHEL 8 to RHEL 9 upgrade but the remediation role skips it as it's not RHEL 7

--- a/changelogs/fragments/sshd_remediation.yml
+++ b/changelogs/fragments/sshd_remediation.yml
@@ -1,0 +1,2 @@
+trivial:
+  - sshd_remediation - remove when condition from sshd_remediation.yml which prevents the issue where the analysis role flags an inhibitor for sshd_config during a RHEL 8 to RHEL 9 upgrade but the remediation role skips it as it's not RHEL 7

--- a/roles/remediate/tasks/leapp_remote_using_root.yml
+++ b/roles/remediate/tasks/leapp_remote_using_root.yml
@@ -1,6 +1,5 @@
 ---
 - name: leapp_remote_using_root | Fix potential issues with remote login using root
-  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 7
   block:
     - name: leapp_remote_using_root | Configure sshd to prohibit-passwords on root login
       ansible.builtin.lineinfile:


### PR DESCRIPTION
This prevents the issue where the analysis role flags an inhibitor for sshd_config during a RHEL 8 to RHEL 9 upgrade but the remediation role skips it as it's not RHEL 7.