### PR TITLE
RHEL 6 remediation for /usr being on a separate partition

### DIFF
--- a/changelogs/fragments/move_usr_directory.yml
+++ b/changelogs/fragments/move_usr_directory.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add remediation role to move /usr directory to root partition when upgrading from RHEL 6 to 7.
+...

--- a/roles/remediate/defaults/main.yml
+++ b/roles/remediate/defaults/main.yml
@@ -15,6 +15,7 @@ remediation_playbooks:
   - leapp_missing_efibootmgr
   - leapp_missing_pkg
   - leapp_missing_yum_plugins
+  - leapp_move_usr_directory
   - leapp_multiple_kernels
   - leapp_newest_kernel_not_in_use
   - leapp_nfs_detected

--- a/roles/remediate/tasks/leapp_move_usr_directory.yml
+++ b/roles/remediate/tasks/leapp_move_usr_directory.yml
@@ -3,36 +3,38 @@
 - name: leapp_move_usr_directory | Move /usr to root partition if on another disk or partition.
   vars:
     entry_title: The /usr/ directory is located on a separate partition. The in-place upgrade is not possible.
-    leapp_report_location: /var/log/leapp/leapp-report.json
+    leapp_report_location: /root/preupgrade/result.txt
   when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 6
   block:
-    - name: leapp_move_usr_directory | Check that the leapp-report.json exists
+    - name: leapp_move_usr_directory | Check that the preupgrade report exists
       ansible.builtin.stat:
         path: "{{ leapp_report_location }}"
       register: leapp_report_stat
 
-    - name: leapp_move_usr_directory | End play if no leapp report exists
+    - name: leapp_move_usr_directory | End play if no preupgrade report exists
       ansible.builtin.set_fact:
         leapp_report_missing: true
       when: leapp_report_stat.stat.exists is false
       failed_when: leapp_report_stat.stat.exists is false
 
-    - name: leapp_move_usr_directory | Read leapp report
+    - name: leapp_move_usr_directory | Read preupgrade report
       ansible.builtin.slurp:
         src: "{{ leapp_report_location }}"
-      register: leappreport
+      register: preupgradereport
 
-    - name: leapp_move_usr_directory | Parse leapp report to json
+    - name: leapp_move_usr_directory | Find matching entries in preupgrade report
       ansible.builtin.set_fact:
-        leappreportdata: "{{ leappreport.content | b64decode | from_json }}"
+        summary: "{{ item }}"
+      loop: "{{ preupgradereport.content | b64decode | splitlines | select('match', entry_title) | list }}"
+      when: item is match(entry_title)
 
-    - name: leapp_move_usr_directory | Find matching entries
+    - name: leapp_move_usr_directory | End execution of playbook if no entry found in preupgrade report
       ansible.builtin.set_fact:
-        summary: "{{ item.summary }}"
-      loop: "{{ leappreportdata.entries }}"
-      when: item.title is match(entry_title) and (item.summary | length > 0)
+        leapp_report_missing: true
+      failed_when: summary is not defined
 
-    - name: leapp_move_usr_directory | End execution of playbook if no entry found in leapp report
+
+    - name: leapp_move_usr_directory | End execution of playbook if no entry found in preupgrade report
       ansible.builtin.set_fact:
         leapp_report_missing: true
       failed_when: summary is not defined

--- a/roles/remediate/tasks/leapp_move_usr_directory.yml
+++ b/roles/remediate/tasks/leapp_move_usr_directory.yml
@@ -1,130 +1,167 @@
 ---
-- name: leapp_move_usr_directory | Move /usr to root partition if on another disk or partition
+# This remediation is only necessary when upgrading from RHEL 6 to 7.
+- name: leapp_move_usr_directory | Move /usr to root partition if on another disk or partition.
+  vars:
+    entry_title: The /usr/ directory is located on a separate partition. The in-place upgrade is not possible.
+    leapp_report_location: /var/log/leapp/leapp-report.json
+  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version|int == 6
   block:
-    - name: Check if /usr is mounted on a separate filesystem
+    - name: leapp_move_usr_directory | Check that the leapp-report.json exists
+      ansible.builtin.stat:
+        path: "{{ leapp_report_location }}"
+      register: leapp_report_stat
+
+    - name: leapp_move_usr_directory | End play if no leapp report exists
       ansible.builtin.set_fact:
-        usr_mount_source: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr') | map(attribute='device') | first | default('') }}"
-        root_mount_source: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='device') | first }}"
-        usr_is_mounted: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr') | list | length > 0 }}"
-        usr_local_is_mounted: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr/local') | list | length > 0 }}"
+        leapp_report_missing: true
+      when: leapp_report_stat.stat.exists is false
+      failed_when: leapp_report_stat.stat.exists is false
 
-    - name: leapp_move_usr_directory | Fail if /usr is not on a separate filesystem
-      ansible.builtin.fail:
-        msg: "This playbook is designed for systems where /usr is mounted on a separate filesystem. /usr is not mounted separately."
-      when: not usr_is_mounted
+    - name: leapp_move_usr_directory | Read leapp report
+      ansible.builtin.slurp:
+        src: "{{ leapp_report_location }}"
+      register: leappreport
 
-    - name: leapp_move_usr_directory | Get root mount information
+    - name: leapp_move_usr_directory | Parse leapp report to json
       ansible.builtin.set_fact:
-        root_mount_source: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='device') | first }}"
+        leappreportdata: "{{ leappreport.content | b64decode | from_json }}"
 
-    - name: leapp_move_usr_directory | Skip if /usr is already on root filesystem
-      ansible.builtin.meta: end_play
-      when: not usr_is_mounted or usr_mount_source == root_mount_source
-
-    - name: leapp_move_usr_directory | Check available space on root filesystem
+    - name: leapp_move_usr_directory | Find matching entries
       ansible.builtin.set_fact:
-        root_space: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='block_size') | first }}"
+        summary: "{{ item.summary }}"
+      loop: "{{ leappreportdata.entries }}"
+      when: item.title is match(entry_title) and (item.summary | length > 0)
 
-    - name: leapp_move_usr_directory | Get /usr size
+    - name: leapp_move_usr_directory | End execution of playbook if no entry found in leapp report
       ansible.builtin.set_fact:
-        usr_size: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='block_size') | first }}"
+        leapp_report_missing: true
+      failed_when: summary is not defined
 
-    - name: leapp_move_usr_directory | Get /usr/local size
-      ansible.builtin.set_fact:
-        usr_local_size: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr/local') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'equalto', '/usr/local') | map(attribute='block_size') | first }}"
-      when: usr_local_is_mounted
-
-    - name: leapp_move_usr_directory | Calculate space needed on root filesystem
-      ansible.builtin.set_fact:
-        space_needed: "{{ usr_size | int + usr_local_size | int }}"
-
-    - name: leapp_move_usr_directory | Fail if not enough space on root filesystem
-      ansible.builtin.fail:
-        msg: "Not enough space on root filesystem. Need {{ space_needed | int / 1024 }} KB, have {{ root_space | int / 1024 }} KB"
-      when: space_needed | int > root_space | int
-
-    - name: leapp_move_usr_directory | Ensure temporary mount directories exist
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: directory
-        mode: "0755"
-        owner: root
-        group: root
-      loop:
-        - /mnt/root
-        - /mnt/usr
-
-    - name: leapp_move_usr_directory | Ensure /mnt/usr/local directory exists if /usr/local is mounted
-      ansible.builtin.file:
-        path: /mnt/usr_local
-        state: directory
-        mode: "0755"
-        owner: root
-        group: root
-      when: usr_local_is_mounted
-
-    - name: leapp_move_usr_directory | Ensure /root partition is mounted to /mnt/root
-      ansible.posix.mount:
-        path: /mnt/root
-        src: /
-        fstype: ext4
-        opts: bind
-        state: mounted
-
-    - name: leapp_move_usr_directory | Ensure /usr partition is mounted to /mnt/usr
-      ansible.posix.mount:
-        path: /mnt/usr
-        src: /usr
-        fstype: ext4
-        opts: bind
-        state: mounted
-
-    - name: leapp_move_usr_directory | Copy /usr to /mnt/root/usr
-      ansible.builtin.shell: |
-        set -o pipefail
-        rsync -aHAXv /mnt/usr/* /mnt/root/usr/
-      changed_when: true
-
-    - name: leapp_move_usr_directory | Ensure /usr/local partition is mounted to /mnt/usr_local
-      ansible.posix.mount:
-        path: /mnt/usr_local
-        src: /usr/local
-        fstype: ext4
-        opts: bind
-        state: mounted
-      when: usr_local_is_mounted
-
-    - name: leapp_move_usr_directory | Copy /usr/local to /mnt/root/usr/local
-      ansible.builtin.shell: |
-        set -o pipefail
-        rsync -aHAXv /mnt/usr_local/* /mnt/root/usr/local/
-      when: usr_local_is_mounted
-      changed_when: true
-
-    - name: leapp_move_usr_directory | Ensure /usr line is removed from /etc/fstab
-      ansible.builtin.lineinfile:
-        path: /etc/fstab
-        regexp: "/usr "
-        state: absent
-
-    - name: leapp_move_usr_directory | Ensure /usr/local line is removed from /etc/fstab
-      ansible.builtin.lineinfile:
-        path: /etc/fstab
-        regexp: "/usr/local "
-        state: absent
-      when: usr_local_is_mounted
-
-    - name: leapp_move_usr_directory | Reboot the system
-      ansible.builtin.reboot:
-        msg: "Rebooting the system to complete the move of /usr"
-        connect_timeout: 5
-        pre_reboot_delay: 0
-        post_reboot_delay: 0
-
+    - name: leapp_move_usr_directory | Move the /usr directory
+      block:
+        - name: Check if /usr is mounted on a separate filesystem
+          ansible.builtin.set_fact:
+            usr_mount_source: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr') | map(attribute='device') | first | default('') }}"
+            root_mount_source: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='device') | first }}"
+            usr_is_mounted: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr') | list | length > 0 }}"
+            usr_local_is_mounted: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr/local') | list | length > 0 }}"
+    
+        - name: leapp_move_usr_directory | Fail if /usr is not on a separate filesystem
+          ansible.builtin.fail:
+            msg: "This playbook is designed for systems where /usr is mounted on a separate filesystem. /usr is not mounted separately."
+          when: not usr_is_mounted
+    
+        - name: leapp_move_usr_directory | Get root mount information
+          ansible.builtin.set_fact:
+            root_mount_source: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='device') | first }}"
+    
+        - name: leapp_move_usr_directory | Skip if /usr is already on root filesystem
+          ansible.builtin.meta: end_play
+          when: not usr_is_mounted or usr_mount_source == root_mount_source
+    
+        - name: leapp_move_usr_directory | Check available space on root filesystem
+          ansible.builtin.set_fact:
+            root_space: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='block_size') | first }}"
+    
+        - name: leapp_move_usr_directory | Get /usr size
+          ansible.builtin.set_fact:
+            usr_size: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='block_size') | first }}"
+    
+        - name: leapp_move_usr_directory | Get /usr/local size
+          ansible.builtin.set_fact:
+            usr_local_size: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr/local') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'equalto', '/usr/local') | map(attribute='block_size') | first }}"
+          when: usr_local_is_mounted
+    
+        - name: leapp_move_usr_directory | Calculate space needed on root filesystem
+          ansible.builtin.set_fact:
+            space_needed: "{{ usr_size | int + usr_local_size | int }}"
+    
+        - name: leapp_move_usr_directory | Fail if not enough space on root filesystem
+          ansible.builtin.fail:
+            msg: "Not enough space on root filesystem. Need {{ space_needed | int / 1024 }} KB, have {{ root_space | int / 1024 }} KB"
+          when: space_needed | int > root_space | int
+    
+        - name: leapp_move_usr_directory | Ensure temporary mount directories exist
+          ansible.builtin.file:
+            path: "{{ item }}"
+            state: directory
+            mode: "0755"
+            owner: root
+            group: root
+          loop:
+            - /mnt/root
+            - /mnt/usr
+    
+        - name: leapp_move_usr_directory | Ensure /mnt/usr/local directory exists if /usr/local is mounted
+          ansible.builtin.file:
+            path: /mnt/usr_local
+            state: directory
+            mode: "0755"
+            owner: root
+            group: root
+          when: usr_local_is_mounted
+    
+        - name: leapp_move_usr_directory | Ensure /root partition is mounted to /mnt/root
+          ansible.posix.mount:
+            path: /mnt/root
+            src: /
+            fstype: ext4
+            opts: bind
+            state: mounted
+    
+        - name: leapp_move_usr_directory | Ensure /usr partition is mounted to /mnt/usr
+          ansible.posix.mount:
+            path: /mnt/usr
+            src: /usr
+            fstype: ext4
+            opts: bind
+            state: mounted
+    
+        - name: leapp_move_usr_directory | Copy /usr to /mnt/root/usr
+          ansible.builtin.shell: |
+            set -o pipefail
+            rsync -aHAXv /mnt/usr/* /mnt/root/usr/
+          changed_when: true
+    
+        - name: leapp_move_usr_directory | Ensure /usr/local partition is mounted to /mnt/usr_local
+          ansible.posix.mount:
+            path: /mnt/usr_local
+            src: /usr/local
+            fstype: ext4
+            opts: bind
+            state: mounted
+          when: usr_local_is_mounted
+    
+        - name: leapp_move_usr_directory | Copy /usr/local to /mnt/root/usr/local
+          ansible.builtin.shell: |
+            set -o pipefail
+            rsync -aHAXv /mnt/usr_local/* /mnt/root/usr/local/
+          when: usr_local_is_mounted
+          changed_when: true
+    
+        - name: leapp_move_usr_directory | Ensure /usr line is removed from /etc/fstab
+          ansible.builtin.lineinfile:
+            path: /etc/fstab
+            regexp: "/usr "
+            state: absent
+    
+        - name: leapp_move_usr_directory | Ensure /usr/local line is removed from /etc/fstab
+          ansible.builtin.lineinfile:
+            path: /etc/fstab
+            regexp: "/usr/local "
+            state: absent
+          when: usr_local_is_mounted
+    
+        - name: leapp_move_usr_directory | Reboot the system
+          ansible.builtin.reboot:
+            msg: "Rebooting the system to complete the move of /usr"
+            connect_timeout: 5
+            pre_reboot_delay: 0
+            post_reboot_delay: 0
+  
   rescue:
     - name: leapp_move_usr_directory | Continue when /usr is not on a separate filesystem
       ansible.builtin.debug:
         msg: "/usr is not mounted on a separate filesystem. Skipping this task."
       when: not usr_is_mounted
-
 ...

--- a/roles/remediate/tasks/leapp_move_usr_directory.yml
+++ b/roles/remediate/tasks/leapp_move_usr_directory.yml
@@ -35,10 +35,26 @@
       block:
         - name: Check if /usr is mounted on a separate filesystem
           ansible.builtin.set_fact:
-            usr_mount_source: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr') | map(attribute='device') | first | default('') }}"
-            root_mount_source: "{{ ansible_mounts | selectattr('mount', 'eq', '/') | map(attribute='device') | first }}"
-            usr_is_mounted: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr') | list | length > 0 }}"
-            usr_local_is_mounted: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr/local') | list | length > 0 }}"
+            usr_mount_source: "{{ item.device }}"
+          loop: "{{ ansible_mounts }}"
+          when: item.mount == '/usr'
+
+        - name: Check root mount source
+          ansible.builtin.set_fact:
+            root_mount_source: "{{ item.device }}"
+          loop: "{{ ansible_mounts }}"
+          when: item.mount == '/'
+
+        - name: Check if /usr/local is mounted
+          ansible.builtin.set_fact:
+            usr_local_mount_source: "{{ item.device }}"
+          loop: "{{ ansible_mounts }}"
+          when: item.mount == '/usr/local'
+
+        - name: Set mount status facts
+          ansible.builtin.set_fact:
+            usr_is_mounted: "{{ usr_mount_source is defined }}"
+            usr_local_is_mounted: "{{ usr_local_mount_source is defined }}"
     
         - name: leapp_move_usr_directory | Fail if /usr is not on a separate filesystem
           ansible.builtin.fail:
@@ -47,7 +63,9 @@
     
         - name: leapp_move_usr_directory | Get root mount information
           ansible.builtin.set_fact:
-            root_mount_source: "{{ ansible_mounts | selectattr('mount', 'eq', '/') | map(attribute='device') | first }}"
+            root_mount_source: "{{ item.device }}"
+          loop: "{{ ansible_mounts }}"
+          when: item.mount == '/' and root_mount_source is not defined
     
         - name: leapp_move_usr_directory | Skip if /usr is already on root filesystem
           ansible.builtin.meta: end_play
@@ -55,20 +73,25 @@
     
         - name: leapp_move_usr_directory | Check available space on root filesystem
           ansible.builtin.set_fact:
-            root_space: "{{ ansible_mounts | selectattr('mount', 'eq', '/') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'eq', '/') | map(attribute='block_size') | first }}"
+            root_space: "{{ item.block_available * item.block_size }}"
+          loop: "{{ ansible_mounts }}"
+          when: item.mount == '/'
     
         - name: leapp_move_usr_directory | Get /usr size
           ansible.builtin.set_fact:
-            usr_size: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'eq', '/') | map(attribute='block_size') | first }}"
+            usr_size: "{{ item.block_available * item.block_size }}"
+          loop: "{{ ansible_mounts }}"
+          when: item.mount == '/usr'
     
         - name: leapp_move_usr_directory | Get /usr/local size
           ansible.builtin.set_fact:
-            usr_local_size: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr/local') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'eq', '/usr/local') | map(attribute='block_size') | first }}"
-          when: usr_local_is_mounted
+            usr_local_size: "{{ item.block_available * item.block_size }}"
+          loop: "{{ ansible_mounts }}"
+          when: item.mount == '/usr/local' and usr_local_is_mounted
     
         - name: leapp_move_usr_directory | Calculate space needed on root filesystem
           ansible.builtin.set_fact:
-            space_needed: "{{ usr_size | int + usr_local_size | int }}"
+            space_needed: "{{ usr_size | int + (usr_local_size | default(0) | int) }}"
     
         - name: leapp_move_usr_directory | Fail if not enough space on root filesystem
           ansible.builtin.fail:

--- a/roles/remediate/tasks/leapp_move_usr_directory.yml
+++ b/roles/remediate/tasks/leapp_move_usr_directory.yml
@@ -1,0 +1,130 @@
+---
+- name: leapp_move_usr_directory | Move /usr to root partition if on another disk or partition
+  block:
+    - name: Check if /usr is mounted on a separate filesystem
+      ansible.builtin.set_fact:
+        usr_mount_source: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr') | map(attribute='device') | first | default('') }}"
+        root_mount_source: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='device') | first }}"
+        usr_is_mounted: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr') | list | length > 0 }}"
+        usr_local_is_mounted: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr/local') | list | length > 0 }}"
+
+    - name: leapp_move_usr_directory | Fail if /usr is not on a separate filesystem
+      ansible.builtin.fail:
+        msg: "This playbook is designed for systems where /usr is mounted on a separate filesystem. /usr is not mounted separately."
+      when: not usr_is_mounted
+
+    - name: leapp_move_usr_directory | Get root mount information
+      ansible.builtin.set_fact:
+        root_mount_source: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='device') | first }}"
+
+    - name: leapp_move_usr_directory | Skip if /usr is already on root filesystem
+      ansible.builtin.meta: end_play
+      when: not usr_is_mounted or usr_mount_source == root_mount_source
+
+    - name: leapp_move_usr_directory | Check available space on root filesystem
+      ansible.builtin.set_fact:
+        root_space: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='block_size') | first }}"
+
+    - name: leapp_move_usr_directory | Get /usr size
+      ansible.builtin.set_fact:
+        usr_size: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='block_size') | first }}"
+
+    - name: leapp_move_usr_directory | Get /usr/local size
+      ansible.builtin.set_fact:
+        usr_local_size: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr/local') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'equalto', '/usr/local') | map(attribute='block_size') | first }}"
+      when: usr_local_is_mounted
+
+    - name: leapp_move_usr_directory | Calculate space needed on root filesystem
+      ansible.builtin.set_fact:
+        space_needed: "{{ usr_size | int + usr_local_size | int }}"
+
+    - name: leapp_move_usr_directory | Fail if not enough space on root filesystem
+      ansible.builtin.fail:
+        msg: "Not enough space on root filesystem. Need {{ space_needed | int / 1024 }} KB, have {{ root_space | int / 1024 }} KB"
+      when: space_needed | int > root_space | int
+
+    - name: leapp_move_usr_directory | Ensure temporary mount directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+        owner: root
+        group: root
+      loop:
+        - /mnt/root
+        - /mnt/usr
+
+    - name: leapp_move_usr_directory | Ensure /mnt/usr/local directory exists if /usr/local is mounted
+      ansible.builtin.file:
+        path: /mnt/usr_local
+        state: directory
+        mode: "0755"
+        owner: root
+        group: root
+      when: usr_local_is_mounted
+
+    - name: leapp_move_usr_directory | Ensure /root partition is mounted to /mnt/root
+      ansible.posix.mount:
+        path: /mnt/root
+        src: /
+        fstype: ext4
+        opts: bind
+        state: mounted
+
+    - name: leapp_move_usr_directory | Ensure /usr partition is mounted to /mnt/usr
+      ansible.posix.mount:
+        path: /mnt/usr
+        src: /usr
+        fstype: ext4
+        opts: bind
+        state: mounted
+
+    - name: leapp_move_usr_directory | Copy /usr to /mnt/root/usr
+      ansible.builtin.shell: |
+        set -o pipefail
+        rsync -aHAXv /mnt/usr/* /mnt/root/usr/
+      changed_when: true
+
+    - name: leapp_move_usr_directory | Ensure /usr/local partition is mounted to /mnt/usr_local
+      ansible.posix.mount:
+        path: /mnt/usr_local
+        src: /usr/local
+        fstype: ext4
+        opts: bind
+        state: mounted
+      when: usr_local_is_mounted
+
+    - name: leapp_move_usr_directory | Copy /usr/local to /mnt/root/usr/local
+      ansible.builtin.shell: |
+        set -o pipefail
+        rsync -aHAXv /mnt/usr_local/* /mnt/root/usr/local/
+      when: usr_local_is_mounted
+      changed_when: true
+
+    - name: leapp_move_usr_directory | Ensure /usr line is removed from /etc/fstab
+      ansible.builtin.lineinfile:
+        path: /etc/fstab
+        regexp: "/usr "
+        state: absent
+
+    - name: leapp_move_usr_directory | Ensure /usr/local line is removed from /etc/fstab
+      ansible.builtin.lineinfile:
+        path: /etc/fstab
+        regexp: "/usr/local "
+        state: absent
+      when: usr_local_is_mounted
+
+    - name: leapp_move_usr_directory | Reboot the system
+      ansible.builtin.reboot:
+        msg: "Rebooting the system to complete the move of /usr"
+        connect_timeout: 5
+        pre_reboot_delay: 0
+        post_reboot_delay: 0
+
+  rescue:
+    - name: leapp_move_usr_directory | Continue when /usr is not on a separate filesystem
+      ansible.builtin.debug:
+        msg: "/usr is not mounted on a separate filesystem. Skipping this task."
+      when: not usr_is_mounted
+
+...

--- a/roles/remediate/tasks/leapp_move_usr_directory.yml
+++ b/roles/remediate/tasks/leapp_move_usr_directory.yml
@@ -35,10 +35,10 @@
       block:
         - name: Check if /usr is mounted on a separate filesystem
           ansible.builtin.set_fact:
-            usr_mount_source: "{{ ansible_mounts | selectattr('mount', '==', '/usr') | map(attribute='device') | first | default('') }}"
-            root_mount_source: "{{ ansible_mounts | selectattr('mount', '==', '/') | map(attribute='device') | first }}"
-            usr_is_mounted: "{{ ansible_mounts | selectattr('mount', '==', '/usr') | list | length > 0 }}"
-            usr_local_is_mounted: "{{ ansible_mounts | selectattr('mount', '==', '/usr/local') | list | length > 0 }}"
+            usr_mount_source: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr') | map(attribute='device') | first | default('') }}"
+            root_mount_source: "{{ ansible_mounts | selectattr('mount', 'eq', '/') | map(attribute='device') | first }}"
+            usr_is_mounted: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr') | list | length > 0 }}"
+            usr_local_is_mounted: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr/local') | list | length > 0 }}"
     
         - name: leapp_move_usr_directory | Fail if /usr is not on a separate filesystem
           ansible.builtin.fail:
@@ -47,7 +47,7 @@
     
         - name: leapp_move_usr_directory | Get root mount information
           ansible.builtin.set_fact:
-            root_mount_source: "{{ ansible_mounts | selectattr('mount', '==', '/') | map(attribute='device') | first }}"
+            root_mount_source: "{{ ansible_mounts | selectattr('mount', 'eq', '/') | map(attribute='device') | first }}"
     
         - name: leapp_move_usr_directory | Skip if /usr is already on root filesystem
           ansible.builtin.meta: end_play
@@ -55,15 +55,15 @@
     
         - name: leapp_move_usr_directory | Check available space on root filesystem
           ansible.builtin.set_fact:
-            root_space: "{{ ansible_mounts | selectattr('mount', '==', '/') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', '==', '/') | map(attribute='block_size') | first }}"
+            root_space: "{{ ansible_mounts | selectattr('mount', 'eq', '/') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'eq', '/') | map(attribute='block_size') | first }}"
     
         - name: leapp_move_usr_directory | Get /usr size
           ansible.builtin.set_fact:
-            usr_size: "{{ ansible_mounts | selectattr('mount', '==', '/usr') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', '==', '/') | map(attribute='block_size') | first }}"
+            usr_size: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'eq', '/') | map(attribute='block_size') | first }}"
     
         - name: leapp_move_usr_directory | Get /usr/local size
           ansible.builtin.set_fact:
-            usr_local_size: "{{ ansible_mounts | selectattr('mount', '==', '/usr/local') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', '==', '/usr/local') | map(attribute='block_size') | first }}"
+            usr_local_size: "{{ ansible_mounts | selectattr('mount', 'eq', '/usr/local') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'eq', '/usr/local') | map(attribute='block_size') | first }}"
           when: usr_local_is_mounted
     
         - name: leapp_move_usr_directory | Calculate space needed on root filesystem

--- a/roles/remediate/tasks/leapp_move_usr_directory.yml
+++ b/roles/remediate/tasks/leapp_move_usr_directory.yml
@@ -22,16 +22,14 @@
         src: "{{ leapp_report_location }}"
       register: preupgradereport
 
-    - name: leapp_move_usr_directory | Find matching entries in preupgrade report
+    - name: leapp_move_usr_directory | Check if entry exists in preupgrade report
       ansible.builtin.set_fact:
-        summary: "{{ item }}"
-      loop: "{{ (preupgradereport.content | b64decode).split('\n') }}"
-      when: entry_title in item
+        entry_found: "{{ entry_title in (preupgradereport.content | b64decode) }}"
 
     - name: leapp_move_usr_directory | End execution of playbook if no entry found in preupgrade report
       ansible.builtin.set_fact:
         leapp_report_missing: true
-      failed_when: summary is not defined
+      failed_when: not entry_found
 
     - name: leapp_move_usr_directory | Move the /usr directory
       block:

--- a/roles/remediate/tasks/leapp_move_usr_directory.yml
+++ b/roles/remediate/tasks/leapp_move_usr_directory.yml
@@ -35,10 +35,10 @@
       block:
         - name: Check if /usr is mounted on a separate filesystem
           ansible.builtin.set_fact:
-            usr_mount_source: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr') | map(attribute='device') | first | default('') }}"
-            root_mount_source: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='device') | first }}"
-            usr_is_mounted: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr') | list | length > 0 }}"
-            usr_local_is_mounted: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr/local') | list | length > 0 }}"
+            usr_mount_source: "{{ ansible_mounts | selectattr('mount', '==', '/usr') | map(attribute='device') | first | default('') }}"
+            root_mount_source: "{{ ansible_mounts | selectattr('mount', '==', '/') | map(attribute='device') | first }}"
+            usr_is_mounted: "{{ ansible_mounts | selectattr('mount', '==', '/usr') | list | length > 0 }}"
+            usr_local_is_mounted: "{{ ansible_mounts | selectattr('mount', '==', '/usr/local') | list | length > 0 }}"
     
         - name: leapp_move_usr_directory | Fail if /usr is not on a separate filesystem
           ansible.builtin.fail:
@@ -47,7 +47,7 @@
     
         - name: leapp_move_usr_directory | Get root mount information
           ansible.builtin.set_fact:
-            root_mount_source: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='device') | first }}"
+            root_mount_source: "{{ ansible_mounts | selectattr('mount', '==', '/') | map(attribute='device') | first }}"
     
         - name: leapp_move_usr_directory | Skip if /usr is already on root filesystem
           ansible.builtin.meta: end_play
@@ -55,15 +55,15 @@
     
         - name: leapp_move_usr_directory | Check available space on root filesystem
           ansible.builtin.set_fact:
-            root_space: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='block_size') | first }}"
+            root_space: "{{ ansible_mounts | selectattr('mount', '==', '/') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', '==', '/') | map(attribute='block_size') | first }}"
     
         - name: leapp_move_usr_directory | Get /usr size
           ansible.builtin.set_fact:
-            usr_size: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='block_size') | first }}"
+            usr_size: "{{ ansible_mounts | selectattr('mount', '==', '/usr') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', '==', '/') | map(attribute='block_size') | first }}"
     
         - name: leapp_move_usr_directory | Get /usr/local size
           ansible.builtin.set_fact:
-            usr_local_size: "{{ ansible_mounts | selectattr('mount', 'equalto', '/usr/local') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', 'equalto', '/usr/local') | map(attribute='block_size') | first }}"
+            usr_local_size: "{{ ansible_mounts | selectattr('mount', '==', '/usr/local') | map(attribute='block_available') | first * ansible_mounts | selectattr('mount', '==', '/usr/local') | map(attribute='block_size') | first }}"
           when: usr_local_is_mounted
     
         - name: leapp_move_usr_directory | Calculate space needed on root filesystem

--- a/roles/remediate/tasks/leapp_move_usr_directory.yml
+++ b/roles/remediate/tasks/leapp_move_usr_directory.yml
@@ -14,8 +14,8 @@
     - name: leapp_move_usr_directory | End play if no preupgrade report exists
       ansible.builtin.set_fact:
         leapp_report_missing: true
-      when: leapp_report_stat.stat.exists is false
-      failed_when: leapp_report_stat.stat.exists is false
+      when: not leapp_report_stat.stat.exists
+      failed_when: not leapp_report_stat.stat.exists
 
     - name: leapp_move_usr_directory | Read preupgrade report
       ansible.builtin.slurp:
@@ -25,14 +25,8 @@
     - name: leapp_move_usr_directory | Find matching entries in preupgrade report
       ansible.builtin.set_fact:
         summary: "{{ item }}"
-      loop: "{{ preupgradereport.content | b64decode | splitlines | select('match', entry_title) | list }}"
-      when: item is match(entry_title)
-
-    - name: leapp_move_usr_directory | End execution of playbook if no entry found in preupgrade report
-      ansible.builtin.set_fact:
-        leapp_report_missing: true
-      failed_when: summary is not defined
-
+      loop: "{{ (preupgradereport.content | b64decode).split('\n') }}"
+      when: entry_title in item
 
     - name: leapp_move_usr_directory | End execution of playbook if no entry found in preupgrade report
       ansible.builtin.set_fact:


### PR DESCRIPTION
Add new remediation role to move /usr and /usr/local to the root partition when upgrading from RHEL 6 to 7