### PR TITLE
update report titles and keys

### DIFF
--- a/changelogs/fragments/392-update-report-titles-and-keys.yml
+++ b/changelogs/fragments/392-update-report-titles-and-keys.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+    - Update report titles and keys to align with upstream leapp-repository changes, while preserving backward compatibility.
+
+...

--- a/roles/analysis/vars/main.yml
+++ b/roles/analysis/vars/main.yml
@@ -54,9 +54,6 @@ __leapp_inhibitors_title_map:
   "Firewalld Configuration AllowZoneDrifting Is Unsupported": leapp_firewalld_allowzonedrifting
   "Firewalld Service tftp-client Is Unsupported": leapp_firewalld_unsupported_tftp_client
   "Legacy network configuration found": leapp_legacy_network_configuration
-  "Leapp detected loaded kernel drivers which have been removed in RHEL 8. Upgrade cannot proceed.": leapp_loaded_removed_kernel_drivers
-  "Leapp detected loaded kernel drivers which have been removed in RHEL 9. Upgrade cannot proceed.": leapp_loaded_removed_kernel_drivers
-  "Leapp detected loaded kernel drivers which have been removed in RHEL 10. Upgrade cannot proceed.": leapp_loaded_removed_kernel_drivers
   "efibootmgr package is required on EFI systems": leapp_missing_efibootmgr
   "Package \"leapp-rhui-aws\" is missing": leapp_missing_pkg
   "Package \"leapp-rhui-google\" is missing": leapp_missing_pkg
@@ -79,6 +76,10 @@ __leapp_inhibitors_title_map:
   "Detected RPMs with RSA/SHA1 signature": leapp_rpms_with_rsa_sha1_detected
   "The installed KDE environment is unavailable on RHEL 8": leapp_unavailable_kde
   "Cannot perform the VDO check of block devices": leapp_vdo_check_needed
+  "Leapp detected loaded kernel drivers which have been removed in RHEL 8. Upgrade cannot proceed.": leapp_loaded_removed_kernel_drivers
+  "Leapp detected loaded kernel drivers which have been removed in RHEL 9. Upgrade cannot proceed.": leapp_loaded_removed_kernel_drivers
+  "Leapp detected loaded kernel drivers which have been removed in RHEL 10. Upgrade cannot proceed.": leapp_loaded_removed_kernel_drivers
+  "Leapp detected loaded kernel drivers that have been removed in the target OS. Upgrade cannot proceed.": leapp_loaded_removed_kernel_drivers
 
 # Maps the key attribute of an inhibitor from a report to a remediation task file name
 __leapp_inhibitors_key_map:
@@ -90,9 +91,6 @@ __leapp_inhibitors_key_map:
   5b1cf050e1a877b0358b6e8c612277c591d40c13: leapp_firewalld_allowzonedrifting
   1d169a613d494a966c9b76c48ab0aef1626f5ac9: leapp_firewalld_unsupported_tftp_client
   7de70b43c3c9d20075e30894ac24a4c4e2d70837: leapp_legacy_network_configuration
-  f08a07da902958defa4f5c2699fae9ec2eb67c5b: leapp_loaded_removed_kernel_drivers
-  7ae2961239eec9905e2580fa6309a589b1dca953: leapp_loaded_removed_kernel_drivers
-  48e04852631245aa4afee9adcdc7c2375b8cffb8: leapp_loaded_removed_kernel_drivers
   e2598a162267006cdc4340affef8603d731e34fa: leapp_missing_efibootmgr
   75c945f6ed19532e7d493bafedeb1b82e44750c5: leapp_missing_pkg
   eb93636a777abb26c2598cf10217cde9fa4733ed: leapp_missing_pkg
@@ -115,5 +113,8 @@ __leapp_inhibitors_key_map:
   f16f40f49c2329a2691c0801b94d31b6b3d4f876: leapp_rpms_with_rsa_sha1_detected
   4bada539189b239213b653dae48c383d20dfe97a: leapp_unavailable_kde
   429a99e13b19a7eebadbb8cb35233d8119bcf255: leapp_vdo_check_needed
+  f08a07da902958defa4f5c2699fae9ec2eb67c5b: leapp_loaded_removed_kernel_drivers
+  7ae2961239eec9905e2580fa6309a589b1dca953: leapp_loaded_removed_kernel_drivers
+  48e04852631245aa4afee9adcdc7c2375b8cffb8: leapp_loaded_removed_kernel_drivers
 
 ...

--- a/roles/remediate/tasks/leapp_loaded_removed_kernel_drivers.yml
+++ b/roles/remediate/tasks/leapp_loaded_removed_kernel_drivers.yml
@@ -11,7 +11,7 @@
       - f08a07da902958defa4f5c2699fae9ec2eb67c5b
       - 7ae2961239eec9905e2580fa6309a589b1dca953
       - 48e04852631245aa4afee9adcdc7c2375b8cffb8
-    leapp_inhibitor_title: Leapp detected loaded kernel drivers which have been removed in RHEL \d+. Upgrade cannot proceed.
+    leapp_inhibitor_title: Leapp detected loaded kernel drivers that have been removed in the target OS. Upgrade cannot proceed.
     leapp_report_entries: "{{ leapp_report_data.entries | default([]) }}"
     leapp_inhibitor_entries_by_key: "{{ leapp_report_entries
       | selectattr('key', 'defined')


### PR DESCRIPTION
Some of the titles and keys for reports were updated in the
leapp-repository and this collection needs to reflect it. This patch
simply adds new titles to the title/key maps in order to preserve
functionality with older versions.

The title searched in remediations is updated without preserving the
original one, since the searching by title is a fallback option as
opposed to searching by report key which is the default. Thus, it should
be enough to preserve the old keys there.

The titles and keys were changed in leapp-repository PR#1505, wich
affects only RHEL 8 and above, as RHEL 7 is not maintained in the
upstream repositoy anymore.

Following are relevant **changes in leapp-repository** that are reflected by
this PR.

Titles used before:
- RHEL 7  - Leapp detected loaded kernel drivers which have been removed in RHEL 8. Upgrade cannot proceed.
- RHEL 8  - Leapp detected loaded kernel drivers which have been removed in RHEL 9. Upgrade cannot proceed.
- RHEL 9  - Leapp detected loaded kernel drivers which have been removed in RHEL 10. Upgrade cannot proceed.

Titles used now:
- RHEL 7  - Leapp detected loaded kernel drivers which have been removed in RHEL 8. Upgrade cannot proceed.
- RHEL 8+ - Leapp detected loaded kernel drivers that have been removed in the target OS. Upgrade cannot proceed.

Keys used before:
- RHEL 7  - `f08a07da902958defa4f5c2699fae9ec2eb67c5b`
- RHEL 8  - `7ae2961239eec9905e2580fa6309a589b1dca953`
- RHEL 9  - `48e04852631245aa4afee9adcdc7c2375b8cffb8`

Key used now:
- RHEL 7+ - `f08a07da902958defa4f5c2699fae9ec2eb67c5b`

---

Changes being reflected come from here:
https://github.com/oamg/leapp-repository/pull/1505

This was an update that makes sure titles dont contain distro and its version in the titles since leapp now supports conversions. Notice that the "The installed KDE environment is unavailable on RHEL 8" in the title_map was not changed since it is related to 7to8 upgrade only which is not maintained by leapp upstream anymore.

Jira: RHEL-170715