### PR TITLE
ci: add sanity test for ansible-core 2.16 with Python 3.12

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -26,6 +26,8 @@ jobs:
     #   working_directory: /home/runner/collections
   sanity:
     uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@main
+    with:
+      extra_matrix_entries: '[{"name": "sanity-py3.12-2.16"}]'
   build-import:
     uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@main
   # unit-galaxy:

--- a/changelogs/fragments/ci-sanity-py312-core216.yml
+++ b/changelogs/fragments/ci-sanity-py312-core216.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "CI - add sanity test for ansible-core 2.16 with Python 3.12 to validate compatibility with the AAP 2.4 EE runtime."


### PR DESCRIPTION
## Summary
- Add `sanity-py3.12-2.16` to the CI sanity matrix via `extra_matrix_entries`
- AAP 2.4 now supports Python 3.12 with core 2.16, but this combination was not covered in CI
- Includes changelog fragment

## Test plan
- [ ] Verify the new `sanity-py3.12-2.16` job appears in the CI matrix
- [ ] Verify all existing sanity tests continue to pass
- [ ] Verify the new combination passes