### PR TITLE
update readme and example playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,24 @@ This collection provides Ansible roles for **RHEL in-place upgrades** using the 
 
 These roles are included in the collection. Each has a `README` and examples under its directory.
 
-- `roles/analysis` — Leapp pre-upgrade phase (or Preupgrade Assistant on RHEL 6)
-- `roles/remediate` — Help remediate systems after pre-upgrade
-- `roles/upgrade` — Leapp OS upgrade (or Red Hat Upgrade Tool on RHEL 6)
+- [Analysis](roles/analysis) — runs the Leapp pre-upgrade (or Preupgrade Assistant on RHEL 6), which analyzes the target system for upgradability and flags potential issues.
+- [Remediate](roles/remediate) — runs available remediations for issues found in the pre-upgrade report.
+- [Upgrade](roles/upgrade) — runs the Leapp upgrade (or Red Hat Upgrade Tool on RHEL 6) on the target system and verifies that the upgrade was successful.
+
+### Usage
+
+The typical workflow for an in-place upgrade has three stages:
+
+1. **Analyze** — run the `analysis` role against your hosts. It produces Leapp pre-upgrade reports and, on the controller, generates a `host_vars` directory and a `remediate.yml` playbook with suggested available fixes for inhibitors found on each host.
+2. **Remediate** — review the produced pre-upgrade reports and generated `host_vars` files (each host gets a file listing available remediations), then run the generated `remediate.yml` playbook or write your own to resolve the inhibitors. After remediations are applied, run the `analysis` role again to see if all pre-upgrade inhibitors are resolved.
+3. **Upgrade** — run the `upgrade` role. It checks for remaining inhibitors, performs the Leapp upgrade, reboots the host, and validates the result.
+
+Example playbooks for each stage are in [`playbooks/`](playbooks/). Detailed documentation for upgrading with this ansible collection is also available in the official documentation for upgrading RHEL:
+- [Upgrading from RHEL 8 to RHEL 9](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/upgrading_from_rhel_8_to_rhel_9/index#upgrading-large-deployments-by-using-ansible-roles_upgrading-from-rhel-8-to-rhel-9)
+- [Upgrading from RHEL 9 to RHEL 10](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html-single/upgrading_from_rhel_9_to_rhel_10/index#upgrading-large-deployments-by-using-ansible-roles)
+
+[!IMPORTANT]
+Not all inhibitors can be remediated by the remediate Ansible role, and either must instead be remediated manually or cannot be remediated.
 
 ### Supported RHEL upgrade paths
 
@@ -34,8 +49,6 @@ The collection supports in-place upgrades for the following paths (using Preupgr
 
 The roles have been used in varied environments: on-prem bare metal and VMs with packages from Red Hat CDN, Satellite content views, or internal mirrors (including disconnected layouts). RHEL on Amazon EC2 with BYOS CDN or pay-as-you-go RHUI has been tested; other public clouds are generally feasible when you set the documented role variables for your subscription and repos.
 
-Example playbooks live under `playbooks/`.
-
 ### Out of scope
 
 The `upgrade` role does **not** upgrade third-party products or non-RHEL package sets. For a full stack upgrade you may need extra automation for agents, clustered storage, databases, and similar (for example Veritas InfoScale clustering or [SAP HANA on RHEL](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_for_sap_solutions/)). Packages from non-RHEL repos (for example [Red Hat Software Collections](https://access.redhat.com/support/policy/updates/rhscl), [EPEL](https://docs.fedoraproject.org/en-US/epel/), [RPM Fusion](https://rpmfusion.org/)) are not handled by the role as RHEL content.
@@ -46,18 +59,27 @@ Many workloads remain compatible after an in-place upgrade under [RHEL applicati
 
 - **Ansible / ansible-core:** Must satisfy `requires_ansible` in `meta/runtime.yml`. Use an ansible-core and Automation Platform release that meets that constraint and your organization's support policy.
 - **Python:** Use the Python versions supported for your control node or execution environment together with your chosen ansible-core (see [Ansible Automation Platform](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/) documentation).
-- **Collection dependencies:** This collection requires `fedora.linux_system_roles`.
+- **Collection dependencies:** This collection requires `fedora.linux_system_roles` (or `redhat.rhel_system_roles` on RHEL systems).
 
 > [!IMPORTANT]
 > Managed-node compatibility depends on the Ansible version on the controller. See [Ansible Core compatibility with RHEL 7 and RHEL 6 managed nodes](https://access.redhat.com/articles/6977724) and [Red Hat Ansible Automation Platform life cycle](https://access.redhat.com/support/policy/updates/ansible-automation-platform). Ensure the combination of `meta/runtime.yml`, your Ansible version, and target OS versions is valid for your scenario.
+> It is generally advised, when using control node with RHEL system, to use version of RHEL equal or higher than the target upgrade system of the managed nodes.
 
 ## Installation
 
-Ansible or ansible-core is supplied with Ansible Automation Platform and its execution environments; this section describes **installing the collection** (for example from automation hub or Ansible Galaxy) using the CLI.
+Ansible or ansible-core is supplied with Ansible Automation Platform and its execution environments; this section describes how to **install the collection** using the CLI.
 
-Before using this collection, install it with the Ansible Galaxy command-line tool:
+**Automation Hub** — The collection is published on [Automation Hub](https://console.redhat.com/ansible/automation-hub/collections/published/redhat/leapp/details) as `redhat.leapp`.
 
+**RPM (RHEL 9+)** — The collection is packaged as `ansible-collection-redhat-leapp` in the Appstream repository and is referenced as `redhat.leapp`:
+
+```bash
+dnf install ansible-collection-redhat-leapp
 ```
+
+**Ansible Galaxy:** — The collection is published on Galaxy as `infra.leapp`:
+
+```bash
 ansible-galaxy collection install infra.leapp
 ```
 
@@ -76,13 +98,13 @@ Use `redhat.rhel_system_roles` where documented in role READMEs if that fits you
 
 To upgrade the collection to the latest published version:
 
-```
+```bash
 ansible-galaxy collection install infra.leapp --upgrade
 ```
 
 To install a specific version (example: `1.0.0`):
 
-```
+```bash
 ansible-galaxy collection install infra.leapp:==1.0.0
 ```
 

--- a/changelogs/fragments/399-update-readme-and-example-playbooks.yml
+++ b/changelogs/fragments/399-update-readme-and-example-playbooks.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Update README with usage workflow, RHEL RPM install method, and rework example playbooks.
+...

--- a/playbooks/analysis.yml
+++ b/playbooks/analysis.yml
@@ -1,26 +1,27 @@
 ---
-- name: Analysis
+- name: RHEL pre-upgrade analysis
   hosts: all
-  strategy: free
-  gather_facts: true
   become: true
-  force_handlers: true
+  # strategy: free
+  # gather_facts: true
+  # force_handlers: true
 
   vars:
+    # Upgrade type: cdn (default), satellite, rhui, or custom
     leapp_upgrade_type: satellite
-    leapp_satellite_organization: My Satellite Organization
-    leapp_satellite_activation_key_post_analysis: MY_ACTIVATION_KEY_POST_ANALYSIS
-    leapp_satellite_activation_key: MY_ACTIVATION_KEY
-    # By default the analysis role will use:
-    # analysis_repos_el7: rhel-7-server-extras-rpms
-    # Optionally override the default analysis_repos_el7 to use the upstream copr leapp repository:
-    # analysis_repos_el7: copr:copr.fedorainfracloud.org:group_oamg:leapp
-    leapp_preupg_opts: --target 8.10
+
+    # Variables specific to satellite upgrade type
+    leapp_satellite_organization: <satellite_org>
+    leapp_satellite_activation_key: <activation_key>
+    leapp_satellite_activation_key_post_analysis: <activation_key_post_analysis>
+
+    # Additional variables that inflience the analysis execution (see roles/analysis/README.md)
+    leapp_preupg_opts: --target 9.6
     leapp_answerfile: |
       [remove_pam_pkcs11_module_check]
       confirm = True
   tasks:
-    - name: Generate preupgrade analysis report
+    - name: Generate pre-upgrade analysis report
       ansible.builtin.import_role:
         name: infra.leapp.analysis
 ...

--- a/playbooks/remediate.yml
+++ b/playbooks/remediate.yml
@@ -1,10 +1,14 @@
 ---
 - name: Remediate
   hosts: all
-  strategy: free
   become: true
-  force_handlers: true
+  # strategy: free
+  # gather_facts: true
+  # force_handlers: true
+
   vars:
+    # Executes following remediations for all systems, use host_vars files
+    # to specify remediations per managed node (see roles/remediate/README.md).
     leapp_remediation_todo:
       - leapp_firewalld_allowzonedrifting
       - leapp_missing_pkg

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -1,15 +1,22 @@
 ---
-- name: Upgrade
+- name: RHEL upgrade
   hosts: all
-  strategy: free
   become: true
-  force_handlers: true
+  # strategy: free
+  # gather_facts: true
+  # force_handlers: true
+
   vars:
+    # Upgrade type: cdn (default), satellite, rhui, or custom
     leapp_upgrade_type: satellite
-    leapp_satellite_organization: My Satellite Organization
-    leapp_satellite_activation_key: MY_ACTIVATION_KEY
-    leapp_satellite_activation_key_post_upgrade: MY_ACTIVATION_KEY_POST_UPGRADE
-    leapp_upgrade_opts: --target 8.10
+
+    # Variables specific to satellite upgrade type
+    leapp_satellite_organization: <satellite_org>
+    leapp_satellite_activation_key: <activation_key>
+    leapp_satellite_activation_key_post_analysis: <activation_key_post_analysis>
+
+    # Additional variables that inflience the upgrade execution (see roles/upgrade/README.md)
+    leapp_preupg_opts: --target 9.6
     leapp_update_grub_to_grub_2: true
     leapp_selinux_mode: permissive
   tasks:


### PR DESCRIPTION
Based on the official documentation, this patch updates READMEs and example playbooks to better align with the information provided in the documentation.

This patch:
- adds the Usage section to the main README in order to provide a high level overview of the workflow with the collection.
- adds the RHEL RPM installation information.
- updates playbooks to resemble the ones from the official documentation while keeping bit more verbosity for guidance.

Jira: RHELMISC-28660