### PR TITLE
ci: Use Ansible certification checker v2.0.0

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -35,7 +35,7 @@ concurrency:
 # for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   call:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@2f6d9300ebe9190da3120a740c3a4d5ca2f0f02e # v1.0.0
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v2.0.0
     # If the minimal Ansible Core version your collection supports Ansible
     # is greater than 2.16.0, specify it below.
     # You might also have to specify Python version supported by that version,

--- a/changelogs/fragments/ansible-cert-checker-v2.0.0.yml
+++ b/changelogs/fragments/ansible-cert-checker-v2.0.0.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Use Ansible certification checker version v2.0.0
+
+...


### PR DESCRIPTION
From the Ansible team:

```
This release contains a potentially breaking change (entries in sanity/ignore-*.txt files are now validated too)
and documentation improvements. See the changelog for details.

Since v2.0.0, the project uses immutable releases for better security, so no floating tags like v1 anymore
(v1 is also made immutable and is kept for backwards compatibility).
```

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
