### PR TITLE
fix task names and messages for inhibitor and error detection

### DIFF
--- a/changelogs/fragments/404-update-analysis-report-messages.yml
+++ b/changelogs/fragments/404-update-analysis-report-messages.yml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - Update analysis report messages to mention errors alongside inhibitors, as both are being checked.
+...

--- a/roles/analysis/handlers/main.yml
+++ b/roles/analysis/handlers/main.yml
@@ -27,7 +27,7 @@
   ansible.builtin.debug:
     msg: >-
       The preupgrade analysis report generation is now complete.
-      {{ 'WARNING: Inhibitors' if upgrade_inhibited else 'SUCCESS: No inhibitors' }} found.
+      {{ 'WARNING: Inhibitors or errors' if upgrade_inhibited else 'SUCCESS: No inhibitors or errors' }} found.
       Review the tasks above or the result file at {{ __leapp_report_txt }}.
 
 ...

--- a/roles/analysis/tasks/analysis-leapp.yml
+++ b/roles/analysis/tasks/analysis-leapp.yml
@@ -57,7 +57,7 @@
     - name: analysis-leapp | Include check-results-file.yml
       ansible.builtin.include_tasks: check-results-file.yml
 
-    - name: analysis-leapp | Run parse_leapp_report to check for inhibitors
+    - name: analysis-leapp | Run parse_leapp_report to check for inhibitors and errors
       ansible.builtin.include_role:
         name: infra.leapp.common
         tasks_from: parse_leapp_report.yml

--- a/roles/common/tasks/parse_leapp_report.yml
+++ b/roles/common/tasks/parse_leapp_report.yml
@@ -46,7 +46,7 @@
       ansible.builtin.set_fact:
         leapp_inhibitors: []
 
-    - name: parse_leapp_report | Check for inhibitors
+    - name: parse_leapp_report | Check for inhibitors and errors
       ansible.builtin.set_fact:
         cacheable: "{{ leapp_result_fact_cacheable }}"
         upgrade_inhibited: true

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -1,17 +1,17 @@
 ---
-- name: leapp-upgrade | Run parse_leapp_report to check for inhibitors
+- name: leapp-upgrade | Run parse_leapp_report to check for inhibitors and errors
   ansible.builtin.include_role:
     name: infra.leapp.common
     tasks_from: parse_leapp_report.yml
   when: leapp_check_analysis_results
 
-- name: leapp-upgrade | Verify no inhibitor results found during preupgrade
+- name: leapp-upgrade | Verify no inhibitor or error results found during preupgrade
   ansible.builtin.assert:
     that: not upgrade_inhibited
     msg: |
-      Inhibitors found in the last pre-upgrade analysis report. Remediate the inhibitors first if you haven't
-      done so already and execute the analysis role again before proceeding with the upgrade. If you don't wish
-      to execute the analysis role again and instead let leapp upgrade to recheck for inhibitors, set the
+      Inhibitors or errors found in the last pre-upgrade analysis report. Remediate the inhibitors or errors first
+      if you haven't done so already and execute the analysis role again before proceeding with the upgrade. If you
+      don't wish to execute the analysis role again and instead let leapp upgrade to recheck for inhibitors, set the
       leapp_check_analysis_results variable to false.
   when: leapp_check_analysis_results
 
@@ -65,7 +65,7 @@
       poll: "{{ leapp_async_poll_interval | int }}"
       changed_when: true
   rescue:
-    - name: leapp-upgrade | Run parse_leapp_report to check for inhibitors
+    - name: leapp-upgrade | Run parse_leapp_report to check for inhibitors and errors
       ansible.builtin.include_role:
         name: infra.leapp.common
         tasks_from: parse_leapp_report.yml


### PR DESCRIPTION
Some task names and messages were suggesting they only check for inhibitors although they detected errors at the same time. To make it less confusing renamed these tasks and updated the messages.

Jira: RHEL-170973