### PR TITLE
Use GH feature to automatically generate relnotes for GH release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           git push origin "refs/tags/${VERSION}"
           gh release create "${VERSION}" \
             --title "infra.leapp ${VERSION}" \
-            --notes-file CHANGELOG.rst \
+            --generate-notes \
             --verify-tag \
             "${{ steps.build.outputs.tar_file }}"
 


### PR DESCRIPTION
Using CHANGELOG.rst for release notes is cumbersome because we have to select lines related to the current release. Otherwise the whole changelog is printed in each release RNs.
GH has a feature to automatically generate RNs that this repository had been using before. Let's stick to this to comply with GH practices. CHANGELOG.rst is still available in a file, no need to repeat it in GH RNs.