### PR TITLE
fix(remediate): tighten permissions on postgresql backup (CVE-2026-68563)

### DIFF
--- a/changelogs/fragments/408-fix-postgresql-backup-permissions.yml
+++ b/changelogs/fragments/408-fix-postgresql-backup-permissions.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+    - Tighten permissions on PostgreSQL data backups created during
+      remediation to prevent other users from reading sensitive database
+      contents (CVE-2026-68563).
+...

--- a/roles/remediate/tasks/leapp_old_postgresql_data.yml
+++ b/roles/remediate/tasks/leapp_old_postgresql_data.yml
@@ -2,7 +2,7 @@
 - name: leapp_old_postgresql_data | Backup and then remove /var/lib/pgsql/data for remediation
   vars:
     postgresql_data_path: /var/lib/pgsql/data
-    postgresql_backup_path: /var/backups
+    postgresql_backup_path: /var/backups/leapp
   block:
     - name: leapp_old_postgresql_data | Check if /var/lib/pgsql/data exists
       ansible.builtin.stat:
@@ -24,11 +24,13 @@
             name: tar
             state: present
 
-        - name: leapp_old_postgresql_data | Ensure /var/backups exists
+        - name: leapp_old_postgresql_data | Ensure /var/backups/leapp exists
           ansible.builtin.file:
             path: "{{ postgresql_backup_path }}"
             state: directory
-            mode: "0755"
+            mode: "0700"
+            owner: root
+            group: root
 
         - name: leapp_old_postgresql_data | Create tar.gz archive of postgresql data
           ansible.builtin.command: # noqa: command-instead-of-module
@@ -38,7 +40,9 @@
         - name: leapp_old_postgresql_data | Set permissions on backup archive
           ansible.builtin.file:
             path: "{{ postgresql_backup_path }}/{{ backup_file_name }}"
-            mode: "0755"
+            mode: "0600"
+            owner: root
+            group: root
 
         - name: leapp_old_postgresql_data | Remove original postgresql data
           ansible.builtin.file:

--- a/roles/remediate/tests/tests_leapp_old_postgresql_data.yml
+++ b/roles/remediate/tests/tests_leapp_old_postgresql_data.yml
@@ -15,9 +15,14 @@
           /var/lib/pgsql/data already exists; refusing to remove real data
           during tests.
 
+    - name: Test | Check if /var/backups/leapp exists before test
+      ansible.builtin.stat:
+        path: /var/backups/leapp
+      register: pgsql_backup_dir_pre
+
     - name: Test | Capture existing backups
       ansible.builtin.find:
-        paths: /var/backups
+        paths: /var/backups/leapp
         patterns: "pgsql_data_backup_*.tar.gz"
         file_type: file
       register: pgsql_backups_pre
@@ -52,7 +57,7 @@
 
     - name: Test | Capture backups after remediation
       ansible.builtin.find:
-        paths: /var/backups
+        paths: /var/backups/leapp
         patterns: "pgsql_data_backup_*.tar.gz"
         file_type: file
       register: pgsql_backups_post
@@ -85,8 +90,40 @@
           - pgsql_backup_contents.stdout_lines | select("search", "var/lib/pgsql/data/README.test") | list | length > 0
         fail_msg: Backup does not contain /var/lib/pgsql/data.
 
-    - name: Cleanup | Remove backup archive
+    - name: Test | Stat of backup directory
+      ansible.builtin.stat:
+        path: /var/backups/leapp
+      register: pgsql_backup_dir_stat
+
+    - name: Test | Assert backup directory permissions
+      ansible.builtin.assert:
+        that:
+          - pgsql_backup_dir_stat.stat.mode == "0700"
+          - pgsql_backup_dir_stat.stat.uid == 0
+          - pgsql_backup_dir_stat.stat.gid == 0
+        fail_msg: /var/backups/leapp must be owned by root with mode 0700.
+
+    - name: Test | Stat of backup archive
+      ansible.builtin.stat:
+        path: "{{ pgsql_new_backup }}"
+      register: pgsql_backup_file_stat
+
+    - name: Test | Assert backup archive permissions
+      ansible.builtin.assert:
+        that:
+          - pgsql_backup_file_stat.stat.mode == "0600"
+          - pgsql_backup_file_stat.stat.uid == 0
+          - pgsql_backup_file_stat.stat.gid == 0
+        fail_msg: Backup archive must be owned by root with mode 0600.
+
+    - name: Cleanup | Remove test backup archive
       ansible.builtin.file:
         path: "{{ pgsql_new_backup }}"
         state: absent
       when: pgsql_new_backup | length > 0
+
+    - name: Cleanup | Remove backup directory if it did not exist before test
+      ansible.builtin.file:
+        path: /var/backups/leapp
+        state: absent
+      when: not pgsql_backup_dir_pre.stat.exists


### PR DESCRIPTION
Store backups under /var/backups/leapp (mode 0700) instead of /var/backups to avoid modifying system directory permissions. Set backup archive mode to 0600 to prevent unauthorized access to sensitive PostgreSQL data.

[CVE-2026-68563](https://www.cve.org/CVERecord?id=CVE-2026-68563)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * PostgreSQL migration backups are now stored in a dedicated `/var/backups/leapp` directory.
  * Access is restricted to the owner, with archives using secure permissions to help protect sensitive database contents.
* **Bug Fixes**
  * Backup verification and cleanup now reflect the updated storage location and security settings, ensuring consistent handling during remediation.
  * Improved safeguards help prevent unauthorized access to PostgreSQL backup data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->