### PR TITLE
fix(remediate): prevent controller file copy in corrupted grubenv remediation (CVE-2026-68562)

### DIFF
--- a/changelogs/fragments/409-grubenv-backup-controller-copy.yml
+++ b/changelogs/fragments/409-grubenv-backup-controller-copy.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+    - Fix corrupted grubenv remediation to perform backup and restore
+      operations entirely on the managed node instead of the Ansible controller
+      (CVE-2026-68562).
+...

--- a/roles/remediate/tasks/leapp_corrupted_grubenv_file.yml
+++ b/roles/remediate/tasks/leapp_corrupted_grubenv_file.yml
@@ -47,7 +47,8 @@
           ansible.builtin.copy:
             src: "{{ item }}"
             dest: "{{ item }}.backup"
-            mode: "0644"
+            remote_src: true
+            mode: preserve
           with_items: "{{ files_grub }}"
 
         - name: leapp_corrupted_grubenv_file | Find grub.cfg file
@@ -59,7 +60,8 @@
           ansible.builtin.copy:
             src: "{{ grub_cfg_path.stdout }}"
             dest: "{{ grub_cfg_path.stdout }}.backup"
-            mode: "0644"
+            remote_src: true
+            mode: preserve
 
         - name: leapp_corrupted_grubenv_file | Delete file(s)
           ansible.builtin.file:


### PR DESCRIPTION
Copy tasks in leapp_corrupted_grubenv_file resolved src paths on the Ansible controller instead of the managed node, allowing an attacker with write access to the Leapp report to exfiltrate controller-local files.

- Add remote_src: true to both copy tasks so files are read and written entirely on the managed node
- Use mode: preserve instead of hardcoded 0644 to retain original file permissions on backups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grubenv corruption remediation by backing up and restoring files directly on the managed node.
  * Preserved existing file permissions during backups instead of applying a fixed permission mode.
* **Documentation**
  * Added release documentation for the updated grubenv backup and restore behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->