### PR TITLE
ci: use commit hash for github action, add persist-credentials false

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,12 +1,16 @@
 ---
 name: Yaml and Ansible Lint
 on: [workflow_call] # [push, pull_request, workflow_call]  # yamllint disable-line rule:truthy
+permissions:
+  contents: read
 jobs:
   build:
     name: Ansible Lint # Naming the build is important to use it as a status check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Build collection
         run: ansible-galaxy collection build -vvv
@@ -26,7 +30,7 @@ jobs:
       #   run: ansible-galaxy collection install -r requirements.yml
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@main # or version tag instead of 'main'
+        uses: ansible/ansible-lint@2bac76bbc98f420b20299cbbc4a52a8ce6cbc295 # main
         with:
           args: "--offline"
 ...

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -5,6 +5,9 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -17,23 +20,23 @@ on:
 
 jobs:
   changelog:
-    uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@dc47efd46c312b6ffaf10c274825707a65ac1d86 # main
     if: github.event_name == 'pull_request'
   ansible-lint:
-    # uses: ansible/ansible-content-actions/.github/workflows/ansible_lint.yaml@main
-    uses: redhat-cop/infra.leapp/.github/workflows/ansible-lint.yml@main
+    # uses: ansible/ansible-content-actions/.github/workflows/ansible_lint.yaml@dc47efd46c312b6ffaf10c274825707a65ac1d86 # main
+    uses: redhat-cop/infra.leapp/.github/workflows/ansible-lint.yml@ac6d732c4a6c7b9c6480f864e0c9876053589cfd # main
     # with:
     #   working_directory: /home/runner/collections
   sanity:
-    uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/sanity.yaml@dc47efd46c312b6ffaf10c274825707a65ac1d86 # main
     with:
       extra_matrix_entries: '[{"name": "sanity-py3.12-2.16"}]'
   build-import:
-    uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@main
+    uses: ansible/ansible-content-actions/.github/workflows/build_import.yaml@dc47efd46c312b6ffaf10c274825707a65ac1d86 # main
   # unit-galaxy:
-  #   uses: ansible/ansible-content-actions/.github/workflows/unit.yaml@main
+  #   uses: ansible/ansible-content-actions/.github/workflows/unit.yaml@dc47efd46c312b6ffaf10c274825707a65ac1d86 # main
   # integration:
-  #   uses: ansible/ansible-content-actions/.github/workflows/integration.yaml@main
+  #   uses: ansible/ansible-content-actions/.github/workflows/integration.yaml@dc47efd46c312b6ffaf10c274825707a65ac1d86 # main
   all_green:
     if: ${{ always() }}
     needs:

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -35,7 +35,7 @@ concurrency:
 # for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   call:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v2.0.0
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@db5a7f2ef20e9af0cbaf78796ff4b99c72da91a2
     # If the minimal Ansible Core version your collection supports Ansible
     # is greater than 2.16.0, specify it below.
     # You might also have to specify Python version supported by that version,

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,5 +1,8 @@
 name: CodeSpell
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -14,5 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: codespell-project/actions-codespell@master
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: codespell-project/actions-codespell@3c04c03694eb927ff908b8b5abfe9c58b239b0ae # master

--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   docsite:
     name: Lint extra docsite docs and links
@@ -21,10 +24,12 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/generate-changelog-and-release.yml
+++ b/.github/workflows/generate-changelog-and-release.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Avoid persisting checkout credentials: create-pull-request configures its own
       # auth; both together cause Git to send duplicate Authorization headers (HTTP 400).
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
@@ -91,7 +91,7 @@ jobs:
         run: |
           sed -i "s/^version:.*$/version: ${NEW}/" galaxy.yml
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -110,12 +110,12 @@ jobs:
         run: ansible-galaxy collection install "./infra-leapp-${{ inputs.version }}.tar.gz"
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@main
+        uses: ansible/ansible-lint@2bac76bbc98f420b20299cbbc4a52a8ce6cbc295 # main
         with:
           args: "--offline"
 
       - name: Open pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'Update changelog ${{ inputs.version }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
       github.event.pull_request.base.ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.x'
 

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -38,7 +38,9 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Get head sha of the PR
         id: head_sha
@@ -51,9 +53,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout PR
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ steps.head_sha.outputs.head_sha }}
+          persist-credentials: false
 
       - name: Get supported platforms
         id: supported_platforms
@@ -140,7 +143,7 @@ jobs:
 
       - name: Set commit status as pending
         if: steps.platform_check.outputs.is_supported == 'true'
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a # master
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: pending
@@ -150,7 +153,7 @@ jobs:
 
       - name: Set commit status as success with a description that platform is skipped
         if: steps.platform_check.outputs.is_supported == 'false'
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a # master
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: success
@@ -169,7 +172,7 @@ jobs:
           TF_API_KEY_RH: ${{ secrets.TF_API_KEY_RH }}
 
       - name: Run test in testing farm
-        uses: sclorg/testing-farm-as-github-action@v4
+        uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1 # v4.3.1
         if: steps.platform_check.outputs.is_supported == 'true'
         with:
           git_ref: main
@@ -212,7 +215,7 @@ jobs:
           update_pull_request_status: false
 
       - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@2774e1f040c82ed70a76b4b5cd53bb11ffaedd0a # master
         # always() is to run the step even if the previous step failed
         if: always() && steps.platform_check.outputs.is_supported == 'true'
         with:

--- a/changelogs/fragments/ci-use-commit-hash-add-permissions.yml
+++ b/changelogs/fragments/ci-use-commit-hash-add-permissions.yml
@@ -1,0 +1,5 @@
+---
+trivial:
+  - "CI - use commit hash with github actions"
+  - "CI - add persist-credentials: false where needed"
+  - "CI - add permissions contents: read where needed"


### PR DESCRIPTION
The latest security guidance is to use the full commit hash, which is immutable,
instead of a tag or version, which can be mutable, for the reference to a version
of a github action.  There are known attacks which inserted unauthorized code
in a version tag and moved the tag.  This prevents this sort of attack, at the
cost of more maintenance burden, but dependabot will largely take care of this
for us.

Each version or tag has been replaced with the corresponding commit hash - in some
cases, this is not the latest commit on the main branch, so I would expect to see
some dependabot updates in the near future.  I thought it was safer to do it this
way - preserve existing behavior/functionality - rather than replace and upgrade
to a newer version at the same time.

This also adds `persist-credentials: false` to the actions/checkout tasks so that
any credentials used by that task will not persist for subsequent tasks, for those
workflows that do not need the credentials for subsequent tasks.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added monthly automated checks for GitHub Actions dependencies.
  - Pinned CI and release automation components to immutable revisions for more consistent and predictable builds.
  - Added read-only repository permissions to applicable workflows.
  - Improved checkout security by preventing credentials from being persisted unnecessarily.

- **Bug Fixes**
  - Updated testing, linting, certification, documentation, changelog, and release workflows to use stable, verified automation sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->