### PR TITLE
ci: use exact match for systemroller instead of contains [citest_skip]

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -25,7 +25,7 @@ jobs:
       github.event.issue.pull_request
       && contains(github.event.comment.body, '[citest]')
       && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      || contains('systemroller', github.event.comment.user.login))
+      || github.event.comment.user.login == 'systemroller')
     runs-on: ubuntu-latest
     outputs:
       supported_platforms: ${{ steps.supported_platforms.outputs.supported_platforms }}

--- a/changelogs/fragments/ci-use-login-eq-systemroller.yml
+++ b/changelogs/fragments/ci-use-login-eq-systemroller.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "CI - use exact match for systemroller login instead of contains"


### PR DESCRIPTION
This guards against the possibility of a user with 'systemroller' as part
of the username.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI comment authorization by requiring an exact systemroller login match, preventing similarly named accounts from being accepted.

* **Documentation**
  * Added a changelog entry describing the CI authorization update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->