### PR TITLE
fix(upgrade): install dracut-config-rescue before rescue kernel rebuild

### DIFF
--- a/changelogs/fragments/420-install-dracut-config-rescue.yml
+++ b/changelogs/fragments/420-install-dracut-config-rescue.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Install the required ``dracut-config-rescue`` package to ensure the rescue kernel is recreated correctly after the upgrade."

--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -145,33 +145,8 @@
     tasks_from: custom_local_repos
   when: leapp_upgrade_type == "custom"
 
-- name: leapp-post-upgrade | Find old rescue kernel files
-  ansible.builtin.find:
-    paths:
-      - /boot
-    patterns:
-      - vmlinuz-*rescue*
-      - initramfs-*rescue*
-  register: __rescue_kernel_files
-
-- name: leapp-post-upgrade | Ensure dracut-config-rescue is installed before recreating the rescue kernel
-  ansible.builtin.package:
-    name: dracut-config-rescue
-    state: present
-  when: __rescue_kernel_files.files | length > 0
-
-- name: leapp-post-upgrade | Remove old rescue kernel files
-  ansible.builtin.file:
-    path: "{{ item.path }}"
-    state: absent
-  loop: "{{ __rescue_kernel_files.files }}"
-
-- name: leapp-post-upgrade | Reinstall the rescue kernel files when old ones were found
-  ansible.builtin.shell: >
-    export PATH={{ leapp_os_path }};
-    /usr/lib/kernel/install.d/51-dracut-rescue.install add "$(uname -r)" /boot "/boot/vmlinuz-$(uname -r)"
-  when: __rescue_kernel_files.files | length > 0
-  changed_when: true
+- name: leapp-post-upgrade | Recreate the rescue kernel
+  ansible.builtin.include_tasks: recreate-rescue-kernel.yml
 
 - name: leapp-post-upgrade | Include update-and-reboot.yml
   ansible.builtin.include_role:

--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -154,6 +154,12 @@
       - initramfs-*rescue*
   register: __rescue_kernel_files
 
+- name: leapp-post-upgrade | Ensure dracut-config-rescue is installed before recreating the rescue kernel
+  ansible.builtin.package:
+    name: dracut-config-rescue
+    state: present
+  when: __rescue_kernel_files.files | length > 0
+
 - name: leapp-post-upgrade | Remove old rescue kernel files
   ansible.builtin.file:
     path: "{{ item.path }}"

--- a/roles/upgrade/tasks/recreate-rescue-kernel.yml
+++ b/roles/upgrade/tasks/recreate-rescue-kernel.yml
@@ -1,0 +1,53 @@
+---
+# Recreate the rescue kernel after an upgrade.
+#
+# Input variables:
+#   leapp_os_path (required)
+#     PATH used when running the 51-dracut-rescue.install reinstall script.
+#     Provided by the role defaults (defaults to "$PATH").
+#
+#   __leapp_rescue_boot_path (optional, default: '/boot')
+#     Directory searched for old rescue kernel files and used as the target
+#     directory for the reinstall script. Internal seam overridden by tests to
+#     target a temporary directory instead of /boot.
+#
+#   __leapp_rescue_config_package (optional, default: 'dracut-config-rescue')
+#     Package installed to enable rescue image creation. Internal seam overridden
+#     by tests to force an install failure.
+#
+#   __leapp_rescue_install_script (optional,
+#     default: '/usr/lib/kernel/install.d/51-dracut-rescue.install')
+#     Script invoked to recreate the rescue kernel. Internal seam overridden by
+#     tests with a harmless stub (echo) so the recreation can run without
+#     building a real kernel.
+
+- name: recreate-rescue-kernel | Find old rescue kernel files
+  ansible.builtin.find:
+    paths: "{{ [__leapp_rescue_boot_path | default('/boot')] }}"
+    patterns:
+      - vmlinuz-*rescue*
+      - initramfs-*rescue*
+  register: __rescue_kernel_files
+
+- name: recreate-rescue-kernel | Ensure dracut-config-rescue is installed before recreating the rescue kernel
+  ansible.builtin.package:
+    name: "{{ __leapp_rescue_config_package | default('dracut-config-rescue') }}"
+    state: present
+  when: __rescue_kernel_files.files | length > 0
+  register: __rescue_config_package_install
+
+- name: recreate-rescue-kernel | Remove old rescue kernel files
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ __rescue_kernel_files.files }}"
+
+- name: recreate-rescue-kernel | Reinstall the rescue kernel files when old ones were found
+  ansible.builtin.shell: >
+    export PATH={{ leapp_os_path }};
+    {{ __leapp_rescue_install_script | default('/usr/lib/kernel/install.d/51-dracut-rescue.install') }} add "$(uname -r)"
+    {{ __leapp_rescue_boot_path | default('/boot') }}
+    "{{ __leapp_rescue_boot_path | default('/boot') }}/vmlinuz-$(uname -r)"
+  when: __rescue_kernel_files.files | length > 0
+  changed_when: true
+  register: __rescue_kernel_reinstall

--- a/roles/upgrade/tests/tests_rescue_kernel.yml
+++ b/roles/upgrade/tests/tests_rescue_kernel.yml
@@ -1,0 +1,196 @@
+---
+# Tests roles/upgrade/tasks/recreate-rescue-kernel.yml.
+#
+# It exercises the real task file against a temporary boot directory (via the
+# __leapp_rescue_boot_path seam) so no real /boot files are touched, and
+# replaces the recreation command with `echo` (via the
+# __leapp_rescue_install_script seam) so the scenarios run for real without
+# building a kernel. Echo prints the arguments it received, which lets the
+# tests assert the command runs with the expected script arguments.
+- name: Test recreate-rescue-kernel
+  hosts: all
+  become: true
+  vars:
+    __test_rescue_files:
+      - vmlinuz-6.0.0-1.el9-rescue
+      - initramfs-6.0.0-1.el9-rescue.img
+    # Non-rescue boot files that must never be matched or removed.
+    __test_non_rescue_files:
+      - vmlinuz-6.0.0-1.el9
+      - initramfs-6.0.0-1.el9.img
+    # Harmless stand-in for 51-dracut-rescue.install: echoes its arguments.
+    __test_install_stub: echo
+  tasks:
+    - name: Test | Create temporary boot directory
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: rescue-boot
+      register: __test_boot_dir
+
+    - name: Test | Run rescue kernel scenarios
+      block:
+
+        - name: Test | Scenario 1 - rescue files present are removed and recreated
+          block:
+            - name: Test | Scenario 1 | Create fake rescue kernel files
+              ansible.builtin.file:
+                path: "{{ __test_boot_dir.path }}/{{ item }}"
+                state: touch
+                mode: "0644"
+              loop: "{{ __test_rescue_files }}"
+
+            - name: Test | Scenario 1 | Run recreate-rescue-kernel
+              ansible.builtin.include_role:
+                name: infra.leapp.upgrade
+                tasks_from: recreate-rescue-kernel.yml
+              vars:
+                __leapp_rescue_boot_path: "{{ __test_boot_dir.path }}"
+                __leapp_rescue_install_script: "{{ __test_install_stub }}"
+
+            - name: Test | Scenario 1 | Find rescue files after run
+              ansible.builtin.find:
+                paths:
+                  - "{{ __test_boot_dir.path }}"
+                patterns:
+                  - vmlinuz-*rescue*
+                  - initramfs-*rescue*
+              register: __test_scenario1_files
+
+            - name: Test | Scenario 1 | Assert files found, install triggered, recreation ran with correct args
+              vars:
+                __stdout: "{{ __rescue_kernel_reinstall.stdout }}"
+              ansible.builtin.assert:
+                that:
+                  - __rescue_kernel_files.files | length == __test_rescue_files | length
+                  - not (__rescue_config_package_install.skipped | default(false))
+                  - __test_scenario1_files.files | length == 0
+                  - not (__rescue_kernel_reinstall.skipped | default(false))
+                  - "'add ' in __stdout"
+                  - __test_boot_dir.path in __stdout
+                  - "'/vmlinuz-' in __stdout"
+                fail_msg: >-
+                  With rescue files present, dracut-config-rescue must be
+                  installed, the old rescue files removed, and the recreation
+                  command must run with the expected arguments.
+
+        - name: Test | Scenario 2 - no rescue files, install and recreation are skipped
+          block:
+            - name: Test | Scenario 2 | Empty the boot directory
+              ansible.builtin.file:
+                path: "{{ __test_boot_dir.path }}"
+                state: "{{ item }}"
+                mode: "0755"
+              loop:
+                - absent
+                - directory
+
+            - name: Test | Scenario 2 | Run recreate-rescue-kernel
+              ansible.builtin.include_role:
+                name: infra.leapp.upgrade
+                tasks_from: recreate-rescue-kernel.yml
+              vars:
+                __leapp_rescue_boot_path: "{{ __test_boot_dir.path }}"
+                __leapp_rescue_install_script: "{{ __test_install_stub }}"
+
+            - name: Test | Scenario 2 | Assert install and recreation are skipped
+              ansible.builtin.assert:
+                that:
+                  - __rescue_kernel_files.files | length == 0
+                  - __rescue_config_package_install.skipped | default(false)
+                  - __rescue_kernel_reinstall.skipped | default(false)
+                fail_msg: >-
+                  With no rescue files, the package install and the recreation
+                  command must be skipped.
+
+        # A bogus package name forces a real install failure; the rescue section
+        # catches it and verifies removal did not run (fail-fast ordering).
+        - name: Test | Scenario 3 - package install fails, files are not removed
+          block:
+            - name: Test | Scenario 3 | Recreate fake rescue kernel files
+              ansible.builtin.file:
+                path: "{{ __test_boot_dir.path }}/{{ item }}"
+                state: touch
+                mode: "0644"
+              loop: "{{ __test_rescue_files }}"
+
+            - name: Test | Scenario 3 | Run recreate-rescue-kernel with a bogus package
+              ansible.builtin.include_role:
+                name: infra.leapp.upgrade
+                tasks_from: recreate-rescue-kernel.yml
+              vars:
+                __leapp_rescue_boot_path: "{{ __test_boot_dir.path }}"
+                __leapp_rescue_config_package: infra-leapp-test-nonexistent-package
+
+            - name: Test | Scenario 3 | Fail if the bogus install unexpectedly succeeded
+              ansible.builtin.fail:
+                msg: Expected the bogus package install to fail, but it did not.
+          rescue:
+            - name: Test | Scenario 3 | Assert the package install caused the failure
+              ansible.builtin.assert:
+                that:
+                  - "'Ensure dracut-config-rescue is installed' in ansible_failed_task.name"
+                fail_msg: >-
+                  Expected the dracut-config-rescue install to fail, but the
+                  failure came from a different task:
+                  {{ ansible_failed_task.name }}.
+
+            - name: Test | Scenario 3 | Find rescue files after failed install
+              ansible.builtin.find:
+                paths:
+                  - "{{ __test_boot_dir.path }}"
+                patterns:
+                  - vmlinuz-*rescue*
+                  - initramfs-*rescue*
+              register: __test_scenario3_files
+
+            - name: Test | Scenario 3 | Assert rescue files were not removed
+              ansible.builtin.assert:
+                that:
+                  - __test_scenario3_files.files | length == __test_rescue_files | length
+                fail_msg: >-
+                  Rescue kernel files must not be removed when the
+                  dracut-config-rescue install fails.
+
+        - name: Test | Scenario 4 - only rescue files are removed, non-rescue files survive
+          block:
+            - name: Test | Scenario 4 | Create rescue and non-rescue boot files
+              ansible.builtin.file:
+                path: "{{ __test_boot_dir.path }}/{{ item }}"
+                state: touch
+                mode: "0644"
+              loop: "{{ __test_rescue_files + __test_non_rescue_files }}"
+
+            - name: Test | Scenario 4 | Run recreate-rescue-kernel
+              ansible.builtin.include_role:
+                name: infra.leapp.upgrade
+                tasks_from: recreate-rescue-kernel.yml
+              vars:
+                __leapp_rescue_boot_path: "{{ __test_boot_dir.path }}"
+                __leapp_rescue_install_script: "{{ __test_install_stub }}"
+
+            - name: Test | Scenario 4 | Stat non-rescue files after run
+              ansible.builtin.stat:
+                path: "{{ __test_boot_dir.path }}/{{ item }}"
+              loop: "{{ __test_non_rescue_files }}"
+              register: __test_non_rescue_stat
+
+            - name: Test | Scenario 4 | Assert only rescue files matched and non-rescue survive
+              ansible.builtin.assert:
+                that:
+                  - __rescue_kernel_files.files | length == __test_rescue_files | length
+                  - __rescue_kernel_files.files
+                    | map(attribute='path') | map('basename')
+                    | select('search', 'rescue') | list | length
+                    == __test_rescue_files | length
+                  - __test_non_rescue_stat.results | map(attribute='stat.exists') | min
+                fail_msg: >-
+                  The find step must match only rescue kernel files; non-rescue
+                  boot files (regular kernel or initramfs) must never be
+                  matched and must remain on disk.
+
+      always:
+        - name: Test | Cleanup temporary boot directory
+          ansible.builtin.file:
+            path: "{{ __test_boot_dir.path }}"
+            state: absent
+          tags: tests::cleanup

--- a/tests/tmt/role/upgrade_rescue_kernel/main.fmf
+++ b/tests/tmt/role/upgrade_rescue_kernel/main.fmf
@@ -1,0 +1,9 @@
+summary: Test upgrade role rescue kernel recreation logic
+duration: 10m
+tag:
+  - role_test
+  - upgrade
+environment:
+  TEST_NAME: "Role test: upgrade rescue kernel"
+  PLAYBOOK: "roles/upgrade/tests/tests_rescue_kernel.yml"
+  LOGFILE_PREFIX: "role-upgrade_rescue_kernel"


### PR DESCRIPTION
The 51-dracut-rescue.install script exits early without creating a rescue image unless dracut_rescue_image="yes" is set, which is provided by the dracut-config-rescue package. Without it, removing the old rescue kernel and running the reinstall left the system with no rescue kernel. Ensure the package is present before the rebuild, per the RHEL post-upgrade documentation.


Jira: RHEL-188431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade reliability by installing the rescue-kernel configuration package before recreating existing rescue kernel files.
  * Existing rescue kernels are now safely detected and rebuilt, while upgrades without rescue kernels avoid unnecessary changes.
  * Rescue-kernel files are preserved if package installation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->