### PR TITLE
fix(s390x): run zipl to apply bootloader changes on s390x

### DIFF
--- a/changelogs/fragments/421-call-zipl-on-s390x.yml
+++ b/changelogs/fragments/421-call-zipl-on-s390x.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Call 'zipl' after boot loader changes on s390x architecture."

--- a/roles/remediate/tasks/leapp_cgroups-v1_enabled.yml
+++ b/roles/remediate/tasks/leapp_cgroups-v1_enabled.yml
@@ -54,6 +54,11 @@
           changed_when: leapp_disable_cgroupsv1 is success
           notify: Reboot the system
 
+        - name: leapp_cgroups-v1_enabled | Run zipl to update s390x boot record
+          ansible.builtin.command: zipl
+          when: ansible_facts['architecture'] == 's390x'
+          changed_when: true
+
         - name: leapp_cgroups-v1_enabled | Show the remediation command result
           ansible.builtin.debug:
             msg: leapp_disable_cgroupsv1.stdout_lines

--- a/roles/remediate/tasks/leapp_multiple_kernels.yml
+++ b/roles/remediate/tasks/leapp_multiple_kernels.yml
@@ -19,6 +19,13 @@
       register: set_default_kernel
       changed_when: set_default_kernel is success
 
+    - name: leapp_multiple_kernels | Run zipl to update s390x boot record
+      ansible.builtin.command: zipl
+      when:
+        - ansible_facts['architecture'] == 's390x'
+        - installed_kernels.stdout_lines[0] != current_kernel.stdout
+      changed_when: true
+
     - name: leapp_multiple_kernels | Update-and-reboot | Reboot when updates applied
       ansible.builtin.reboot:
         reboot_timeout: "{{ leapp_reboot_timeout }}"

--- a/roles/remediate/tasks/leapp_newest_kernel_not_in_use.yml
+++ b/roles/remediate/tasks/leapp_newest_kernel_not_in_use.yml
@@ -28,6 +28,11 @@
           register: set_default_kernel
           changed_when: set_default_kernel is success
 
+        - name: leapp_newest_kernel_not_in_use | Run zipl to update s390x boot record
+          ansible.builtin.command: zipl
+          when: ansible_facts['architecture'] == 's390x'
+          changed_when: true
+
         - name: leapp_newest_kernel_not_in_use | Update-and-reboot | Reboot when updates applied
           ansible.builtin.reboot:
             reboot_timeout: "{{ leapp_reboot_timeout }}"

--- a/roles/upgrade/tasks/leapp-post-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-post-upgrade.yml
@@ -148,6 +148,11 @@
 - name: leapp-post-upgrade | Recreate the rescue kernel
   ansible.builtin.include_tasks: recreate-rescue-kernel.yml
 
+- name: leapp-post-upgrade | Run zipl to update s390x boot record
+  ansible.builtin.command: zipl
+  when: ansible_facts['architecture'] == 's390x'
+  changed_when: true
+
 - name: leapp-post-upgrade | Include update-and-reboot.yml
   ansible.builtin.include_role:
     name: infra.leapp.common

--- a/roles/upgrade/tasks/leapp-upgrade.yml
+++ b/roles/upgrade/tasks/leapp-upgrade.yml
@@ -111,7 +111,9 @@
   delay: "{{ leapp_resume_delay }}"
 
 - name: leapp-upgrade | Block to handle grub_boot_device option
-  when: leapp_grub_boot_device is not none
+  when:
+    - leapp_grub_boot_device is not none
+    - ansible_facts['architecture'] != 's390x'
   block:
     - name: leapp-upgrade | Run grub2-install
       ansible.builtin.shell: >


### PR DESCRIPTION
grubby edits boot config on s390x but never invokes zipl, so kernel default/removal/arg changes are not written to the boot record. Add a zipl call after each grubby operation, and skip the grub2-install grub_boot_device block on s390x since it has no zipl equivalent.


Jira: RHEL-178918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootloader updates on s390x systems by refreshing the boot record after kernel or boot configuration changes.
  * Prevented incompatible GRUB installation steps from running on s390x systems.
  * Ensured upgrades and remediations correctly use the updated boot configuration before rebooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->