### PR TITLE
fix(remediation): fix RPM sorting during latest kernel remediation

### DIFF
--- a/changelogs/fragments/256-current-kernel-remediation.yml
+++ b/changelogs/fragments/256-current-kernel-remediation.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Fix latest-kernel remediation to select the newest installed kernel and remove older kernels using RPM version ordering."

--- a/plugins/filter/rpm_sort.py
+++ b/plugins/filter/rpm_sort.py
@@ -1,0 +1,184 @@
+"""Pure-Python RPM EVR comparison filter for Ansible (no rpm module needed).
+
+Implements the rpmvercmp algorithm as specified in rpm-version(7).
+"""
+
+DOCUMENTATION = r"""
+name: rpm_sort
+short_description: Sort a list of RPM package dicts by epoch-version-release (EVR).
+description:
+  - Sorts a list of package dictionaries using RPM's EVR comparison algorithm
+    as specified in rpm-version(7).
+  - Implements full support for epoch, tilde (pre-release), and caret
+    (post-release/snapshot) semantics.
+  - Packages without an explicit epoch (C(None) or C(0)) are treated as epoch 0.
+  - Designed to consume the output of M(ansible.builtin.package_facts) directly.
+positional: _input
+options:
+  _input:
+    description:
+      - A list of dictionaries, each representing an RPM package.
+        Each dictionary must contain C(epoch), C(version), and C(release) keys.
+        Typically the output of C(ansible_facts.packages['<package_name>']).
+      - Alternatively, a dictionary mapping package names to lists of package
+        dicts (i.e. the full C(ansible_facts.packages) structure). In this case
+        all package lists are flattened into one before sorting.
+    type: raw
+    required: true
+author:
+  - Juerg Ritter (jritter@redhat.com)
+"""
+
+EXAMPLES = r"""
+- name: Sort kernel packages from oldest to newest
+  ansible.builtin.set_fact:
+    sorted_kernels: "{{ ansible_facts.packages['kernel'] | infra.leapp.rpm_sort }}"
+
+- name: Get the newest kernel (last element after sorting)
+  ansible.builtin.set_fact:
+    newest_kernel: "{{ ansible_facts.packages['kernel'] | infra.leapp.rpm_sort | last }}"
+
+- name: Sort descending (newest first)
+  ansible.builtin.set_fact:
+    newest_first: "{{ ansible_facts.packages['kernel'] | infra.leapp.rpm_sort | reverse | list }}"
+
+- name: Sort all installed packages together
+  ansible.builtin.set_fact:
+    all_sorted: "{{ ansible_facts.packages | infra.leapp.rpm_sort }}"
+"""
+
+import re
+from functools import cmp_to_key
+
+_SEGMENT_RE = re.compile(r'~|\^|\d+|[a-zA-Z]+')
+
+
+def _rpmvercmp(a, b):
+    """Compare two RPM version/release strings per rpm-version(7)."""
+    if a == b:
+        return 0
+
+    seg_a = _SEGMENT_RE.findall(a)
+    seg_b = _SEGMENT_RE.findall(b)
+
+    i = 0
+    while i < len(seg_a) or i < len(seg_b):
+        sa = seg_a[i] if i < len(seg_a) else None
+        sb = seg_b[i] if i < len(seg_b) else None
+
+        # Tilde sorts older than anything, including absent
+        if sa == '~' or sb == '~':
+            if sa != '~':
+                return 1
+            if sb != '~':
+                return -1
+            i += 1
+            continue
+
+        # Caret sorts newer than absent but older than anything else
+        if sa == '^' or sb == '^':
+            if sa is None:
+                return -1
+            if sb is None:
+                return 1
+            if sa != '^':
+                return 1
+            if sb != '^':
+                return -1
+            i += 1
+            continue
+
+        # One side ran out of segments — the longer one is newer
+        if sa is None:
+            return -1
+        if sb is None:
+            return 1
+
+        a_num = sa.isdigit()
+        b_num = sb.isdigit()
+
+        # Numeric segments are always newer than alpha segments
+        if a_num != b_num:
+            return 1 if a_num else -1
+
+        if a_num:
+            ia, ib = int(sa), int(sb)
+            if ia != ib:
+                return 1 if ia > ib else -1
+        else:
+            if sa < sb:
+                return -1
+            if sa > sb:
+                return 1
+
+        i += 1
+
+    return 0
+
+
+def _label_compare(evr1, evr2):
+    """Compare two (epoch, version, release) tuples per RPM rules."""
+    e1, v1, r1 = evr1
+    e2, v2, r2 = evr2
+
+    # Epoch wins outright
+    ei1, ei2 = int(e1 or 0), int(e2 or 0)
+    if ei1 != ei2:
+        return 1 if ei1 > ei2 else -1
+
+    rc = _rpmvercmp(v1, v2)
+    if rc != 0:
+        return rc
+
+    return _rpmvercmp(r1, r2)
+
+
+def _normalize_epoch(value):
+    """Normalize epoch to a string digits representation.
+
+    Handles None, integer 0, string "None", empty string, and numeric strings
+    as returned by various ansible_facts.packages implementations.
+    """
+    if value is None or value == 'None' or value == '':
+        return '0'
+    return str(int(value))
+
+
+def rpm_sort(packages):
+    """Sort a list of package dicts by EVR using RPM comparison rules.
+
+    Accepts either a list of package dicts or a dict mapping package names
+    to lists of package dicts (as returned by ansible_facts.packages).
+    In the dict case, each package name's list is sorted by EVR independently,
+    then the results are returned sorted by package name.
+    """
+    if isinstance(packages, dict):
+        result = []
+        for name in sorted(packages.keys()):
+            result.extend(sorted(packages[name], key=cmp_to_key(_compare_evr)))
+        return result
+
+    if not packages:
+        return []
+
+    return sorted(packages, key=cmp_to_key(_compare_evr))
+
+
+def _compare_evr(pkg1, pkg2):
+    """Compare two package dicts by epoch-version-release."""
+    e1 = _normalize_epoch(pkg1.get('epoch'))
+    v1 = str(pkg1.get('version', ''))
+    r1 = str(pkg1.get('release', ''))
+
+    e2 = _normalize_epoch(pkg2.get('epoch'))
+    v2 = str(pkg2.get('version', ''))
+    r2 = str(pkg2.get('release', ''))
+
+    return _label_compare((e1, v1, r1), (e2, v2, r2))
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'rpm_sort': rpm_sort,
+        }

--- a/roles/remediate/tasks/leapp_multiple_kernels.yml
+++ b/roles/remediate/tasks/leapp_multiple_kernels.yml
@@ -1,21 +1,32 @@
 ---
 - name: leapp_multiple_kernels | Boot to latest kernel and remove old kernels
   block:
-    - name: leapp_multiple_kernels | Get list of installed kernels packages sorted by the newest version
-      ansible.builtin.shell: |
-        set -o pipefail
-        rpm -q kernel --queryformat '%{version}-%{release}.%{arch}\n' | sort -Vr
-      register: installed_kernels
-      changed_when: false
 
+    - name: leapp_multiple_kernels | Gather package facts
+      ansible.builtin.package_facts:
+        manager: rpm
+
+    - name: leapp_multiple_kernels | Sort kernels by RPM version (newest first)
+      ansible.builtin.set_fact:
+        sorted_kernels: "{{ ansible_facts.packages['kernel'] | infra.leapp.rpm_sort | reverse | list }}"
+
+    - name: leapp_multiple_kernels | Debug sorted kernels
+      ansible.builtin.debug:
+        var: sorted_kernels
+
+    - name: leapp_multiple_kernels | Set fact for latest kernel version
+      ansible.builtin.set_fact:
+        latest_kernel_version: "{{ sorted_kernels[0].version }}-{{ sorted_kernels[0].release }}.{{ sorted_kernels[0].arch }}"
+
+    # example output: 4.18.0-553.157.1.el8_10.x86_64
     - name: leapp_multiple_kernels | Check current kernel version
       ansible.builtin.command: uname -r
       register: current_kernel
       changed_when: false
 
     - name: leapp_multiple_kernels | Set default kernel to latest
-      ansible.builtin.command: grubby --set-default /boot/vmlinuz-{{ installed_kernels.stdout_lines[0] }}
-      when: installed_kernels.stdout_lines[0] != current_kernel.stdout
+      ansible.builtin.command: grubby --set-default /boot/vmlinuz-{{ latest_kernel_version }}
+      when: latest_kernel_version != current_kernel.stdout
       register: set_default_kernel
       changed_when: set_default_kernel is success
 
@@ -23,7 +34,7 @@
       ansible.builtin.command: zipl
       when:
         - ansible_facts['architecture'] == 's390x'
-        - installed_kernels.stdout_lines[0] != current_kernel.stdout
+        - latest_kernel_version != current_kernel.stdout
       changed_when: true
 
     - name: leapp_multiple_kernels | Update-and-reboot | Reboot when updates applied
@@ -31,18 +42,18 @@
         reboot_timeout: "{{ leapp_reboot_timeout }}"
         post_reboot_delay: "{{ leapp_post_reboot_delay }}"
       timeout: "{{ leapp_reboot_timeout }}"
-      when: installed_kernels.stdout_lines[0] != current_kernel.stdout
+      when: latest_kernel_version != current_kernel.stdout
 
     # TODO: This is slow.  Instead, use filters/map to construct the list
     # of package names to remove and pass the list as name:
     - name: leapp_multiple_kernels | Remove old kernels
       ansible.builtin.package:
-        name: kernel-core-{{ item }}
+        name: kernel-core-{{ item.version }}-{{ item.release }}.{{ item.arch }}
         state: absent
-      loop: "{{ installed_kernels.stdout_lines[1:] }}"
+      loop: "{{ sorted_kernels[1:] }}"
 
     - name: leapp_multiple_kernels | Print the list of installed kernels
       ansible.builtin.debug:
-        var: installed_kernels.stdout_lines
+        var: sorted_kernels
 
 ...

--- a/roles/remediate/tasks/leapp_newest_kernel_not_in_use.yml
+++ b/roles/remediate/tasks/leapp_newest_kernel_not_in_use.yml
@@ -1,30 +1,34 @@
 ---
 - name: leapp_newest_kernel_not_in_use | Boot to latest kernel
   block:
-    - name: leapp_newest_kernel_not_in_use | Get list of installed kernels packages sorted by the newest version
-      ansible.builtin.shell: |
-        set -o pipefail
-        rpm -q kernel --queryformat '%{version}-%{release}.%{arch}\n' | sort -Vr
-      register: installed_kernels
-      changed_when: false
 
-    - name: leapp_newest_kernel_not_in_use | Get the default kernel
-      ansible.builtin.shell: |
-        set -o pipefail
-        grubby --default-kernel | sed 's/^\/boot\/vmlinuz\-//'
-      register: default_kernel_version
+    - name: leapp_newest_kernel_not_in_use | Gather package facts
+      ansible.builtin.package_facts:
+        manager: rpm
+
+    - name: leapp_newest_kernel_not_in_use | Sort kernels by RPM version (newest first)
+      ansible.builtin.set_fact:
+        sorted_kernels: "{{ ansible_facts.packages['kernel'] | infra.leapp.rpm_sort | reverse | list }}"
+
+    - name: leapp_newest_kernel_not_in_use | Set fact for latest kernel version
+      ansible.builtin.set_fact:
+        latest_kernel_version: "{{ sorted_kernels[0].version }}-{{ sorted_kernels[0].release }}.{{ sorted_kernels[0].arch }}"
+
+    - name: leapp_newest_kernel_not_in_use | Check current kernel version
+      ansible.builtin.command: uname -r
+      register: current_kernel
       changed_when: false
 
     - name: leapp_newest_kernel_not_in_use | Check the kernel versions
       ansible.builtin.debug:
-        msg: "The newest kernel {{ installed_kernels.stdout_lines[0] }} is already in use. Skipping this task."
-      when: installed_kernels.stdout_lines[0] == default_kernel_version.stdout
+        msg: "The newest kernel {{ latest_kernel_version }} is already in use. Skipping this task."
+      when: latest_kernel_version == current_kernel.stdout
 
     - name: leapp_newest_kernel_not_in_use | Process remediation
-      when: installed_kernels.stdout_lines[0] != default_kernel_version.stdout
+      when: latest_kernel_version != current_kernel.stdout
       block:
         - name: leapp_newest_kernel_not_in_use | Set default kernel to latest
-          ansible.builtin.command: grubby --set-default /boot/vmlinuz-{{ installed_kernels.stdout_lines[0] }}
+          ansible.builtin.command: grubby --set-default /boot/vmlinuz-{{ latest_kernel_version }}
           register: set_default_kernel
           changed_when: set_default_kernel is success
 
@@ -33,7 +37,7 @@
           when: ansible_facts['architecture'] == 's390x'
           changed_when: true
 
-        - name: leapp_newest_kernel_not_in_use | Update-and-reboot | Reboot when updates applied
+        - name: leapp_newest_kernel_not_in_use | Reboot into latest kernel
           ansible.builtin.reboot:
             reboot_timeout: "{{ leapp_reboot_timeout }}"
             post_reboot_delay: "{{ leapp_post_reboot_delay }}"

--- a/tests/unit/plugins/filter/test_rpm_sort.py
+++ b/tests/unit/plugins/filter/test_rpm_sort.py
@@ -1,0 +1,298 @@
+"""Unit tests for the pure-Python RPM EVR comparison filter."""
+
+import pytest
+from ansible_collections.infra.leapp.plugins.filter.rpm_sort import (
+    _rpmvercmp,
+    _label_compare,
+    _normalize_epoch,
+    rpm_sort,
+)
+
+
+# ---------------------------------------------------------------------------
+# _rpmvercmp — low-level version string comparison
+# ---------------------------------------------------------------------------
+
+class TestRpmvercmp:
+    """Test cases derived from rpm-version(7) spec and real-world edge cases."""
+
+    @pytest.mark.parametrize("a, b", [
+        ("1.0", "1.0"),
+        ("0001", "1"),       # leading zeros ignored
+        ("abc", "abc"),
+        ("", ""),
+    ])
+    def test_equal(self, a, b):
+        assert _rpmvercmp(a, b) == 0
+
+    @pytest.mark.parametrize("newer, older", [
+        ("1.1", "1.0"),
+        ("2.0", "1.999"),
+        ("10", "9"),         # numeric, not lexicographic
+        ("1.0.1", "1.0"),    # more segments = newer
+        ("0.0", "0"),        # more segments = newer
+    ])
+    def test_numeric_ordering(self, newer, older):
+        assert _rpmvercmp(newer, older) == 1
+        assert _rpmvercmp(older, newer) == -1
+
+    @pytest.mark.parametrize("newer, older", [
+        ("b", "a"),
+        ("add", "ab"),
+    ])
+    def test_alpha_ordering(self, newer, older):
+        assert _rpmvercmp(newer, older) == 1
+        assert _rpmvercmp(older, newer) == -1
+
+    def test_numeric_beats_alpha(self):
+        """Numeric segments are always newer than alpha segments."""
+        assert _rpmvercmp("1", "a") == 1
+        assert _rpmvercmp("a", "1") == -1
+
+    @pytest.mark.parametrize("newer, older", [
+        ("1.0", "1.0~beta1"),    # release > pre-release
+        ("1.0~rc1", "1.0~beta1"),
+    ])
+    def test_tilde_pre_release(self, newer, older):
+        assert _rpmvercmp(newer, older) == 1
+        assert _rpmvercmp(older, newer) == -1
+
+    @pytest.mark.parametrize("newer, older", [
+        ("2.0^150825", "2.0"),     # snapshot > release
+        ("2.0.1", "2.0^150825"),   # next release > snapshot
+    ])
+    def test_caret_post_release(self, newer, older):
+        assert _rpmvercmp(newer, older) == 1
+        assert _rpmvercmp(older, newer) == -1
+
+    def test_leading_zeros_ignored(self):
+        assert _rpmvercmp("001", "1") == 0
+        assert _rpmvercmp("0100", "100") == 0
+
+
+# ---------------------------------------------------------------------------
+# _label_compare — full (epoch, version, release) comparison
+# ---------------------------------------------------------------------------
+
+class TestLabelCompare:
+
+    def test_epoch_wins(self):
+        assert _label_compare(("2", "1.0", "1"), ("1", "9.9", "99")) == 1
+
+    def test_epoch_zero_default(self):
+        assert _label_compare(("0", "1.0", "1"), ("0", "1.0", "1")) == 0
+
+    def test_version_breaks_tie(self):
+        assert _label_compare(("0", "2.0", "1"), ("0", "1.0", "1")) == 1
+
+    def test_release_breaks_tie(self):
+        assert _label_compare(("0", "1.0", "2"), ("0", "1.0", "1")) == 1
+
+    def test_none_epoch_treated_as_zero(self):
+        assert _label_compare(("", "1.0", "1"), ("0", "1.0", "1")) == 0
+
+    def test_epoch_present_vs_absent(self):
+        """A package with epoch=1 always beats one without an epoch."""
+        with_epoch = ("1", "1.0", "1.el9")
+        without_epoch = ("", "99.0", "1.el9")
+        assert _label_compare(with_epoch, without_epoch) == 1
+        assert _label_compare(without_epoch, with_epoch) == -1
+
+
+# ---------------------------------------------------------------------------
+# _normalize_epoch — handle the various epoch representations
+# ---------------------------------------------------------------------------
+
+class TestNormalizeEpoch:
+
+    @pytest.mark.parametrize("value, expected", [
+        (None, "0"),
+        ("None", "0"),
+        ("", "0"),
+        (0, "0"),
+        ("0", "0"),
+        (1, "1"),
+        ("1", "1"),
+        (2, "2"),
+        ("10", "10"),
+    ])
+    def test_normalize(self, value, expected):
+        assert _normalize_epoch(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# rpm_sort — epoch handling with package_facts-style dicts
+# ---------------------------------------------------------------------------
+
+class TestRpmSortEpoch:
+    """Test epoch edge cases as returned by ansible_facts.packages.
+
+    package_facts returns epoch as None when no explicit epoch is set,
+    while packages with an epoch get an integer value.
+    """
+
+    def _pkg(self, version, release, epoch=None):
+        return {"name": "glibc", "epoch": epoch,
+                "version": version, "release": release, "arch": "x86_64"}
+
+    def test_none_epoch_equals_zero_epoch(self):
+        """epoch=None and epoch=0 are equivalent (both mean 'no epoch')."""
+        pkg_none = self._pkg("2.28", "236.el8_9.12")
+        pkg_zero = self._pkg("2.28", "236.el8_9.12", epoch=0)
+        result = rpm_sort([pkg_none, pkg_zero])
+        assert result[0]["epoch"] is None
+        assert result[1]["epoch"] == 0
+
+    def test_string_none_epoch(self):
+        """epoch='None' (as returned by some package_facts) is treated as 0."""
+        pkg_str_none = self._pkg("2.28", "236.el8", epoch="None")
+        pkg_zero = self._pkg("2.28", "236.el8", epoch=0)
+        pkg_real_none = self._pkg("2.28", "236.el8")
+        result = rpm_sort([pkg_str_none, pkg_zero, pkg_real_none])
+        assert all(
+            r["version"] == "2.28" for r in result
+        ), "all three should be equivalent epoch"
+
+    def test_explicit_epoch_beats_no_epoch(self):
+        """epoch=1 wins over epoch=None even with a lower version number."""
+        old_version_with_epoch = self._pkg("1.0", "1.el9", epoch=1)
+        new_version_no_epoch = self._pkg("99.0", "999.el9")
+        result = rpm_sort([new_version_no_epoch, old_version_with_epoch])
+        assert result[-1] == old_version_with_epoch, (
+            "epoch=1 must sort newer than no epoch regardless of version"
+        )
+
+    def test_both_none_epoch_falls_through_to_version(self):
+        """When both packages have epoch=None, version decides."""
+        older = self._pkg("2.28", "236.el8")
+        newer = self._pkg("2.34", "100.el9")
+        result = rpm_sort([newer, older])
+        assert result == [older, newer]
+
+    def test_mixed_epoch_types_in_list(self):
+        """Sorting works with a mix of None, 0, and integer epochs."""
+        pkg_none = self._pkg("5.0", "1.el9")          # epoch=None -> 0
+        pkg_zero = self._pkg("5.0", "1.el9", epoch=0)  # epoch=0 -> 0
+        pkg_one = self._pkg("1.0", "1.el9", epoch=1)   # epoch=1
+        pkg_two = self._pkg("0.1", "1.el9", epoch=2)   # epoch=2
+        result = rpm_sort([pkg_two, pkg_none, pkg_one, pkg_zero])
+        assert result[0]["epoch"] is None
+        assert result[1]["epoch"] == 0
+        assert result[2]["epoch"] == 1
+        assert result[3]["epoch"] == 2
+
+
+# ---------------------------------------------------------------------------
+# The real-world kernel case that started this whole thing
+# ---------------------------------------------------------------------------
+
+class TestKernelSortCase:
+    """553.157.1.el8_10 is newer than 553.el8_10 per RPM rules."""
+
+    def test_z_stream_newer_than_base(self):
+        result = _rpmvercmp("553.157.1.el8_10", "553.el8_10")
+        assert result == 1, "z-stream update must sort newer than base release"
+
+    def test_kernel_packages_sort(self):
+        base = {
+            "name": "kernel", "epoch": 0,
+            "version": "4.18.0", "release": "553.el8_10", "arch": "x86_64",
+        }
+        zstream = {
+            "name": "kernel", "epoch": 0,
+            "version": "4.18.0", "release": "553.157.1.el8_10", "arch": "x86_64",
+        }
+        result = rpm_sort([base, zstream])
+        assert result[0] == base
+        assert result[1] == zstream, "z-stream must sort after base (ascending)"
+
+        reversed_result = list(reversed(rpm_sort([zstream, base])))
+        assert reversed_result[0] == zstream, "newest first when reversed"
+
+
+# ---------------------------------------------------------------------------
+# rpm_sort — full filter function with package_facts-style dicts
+# ---------------------------------------------------------------------------
+
+class TestRpmSort:
+
+    def _pkg(self, version, release, epoch=0):
+        return {"name": "kernel", "epoch": epoch,
+                "version": version, "release": release, "arch": "x86_64"}
+
+    def test_ascending_order(self):
+        pkgs = [
+            self._pkg("4.18.0", "553.157.1.el8_10"),
+            self._pkg("4.18.0", "553.el8_10"),
+            self._pkg("4.18.0", "477.10.1.el8_8"),
+        ]
+        result = rpm_sort(pkgs)
+        releases = [p["release"] for p in result]
+        assert releases == ["477.10.1.el8_8", "553.el8_10", "553.157.1.el8_10"]
+
+    def test_epoch_trumps_version(self):
+        old_epoch = self._pkg("1.0", "1.el9", epoch=2)
+        new_version = self._pkg("99.0", "1.el9", epoch=1)
+        result = rpm_sort([new_version, old_epoch])
+        assert result[-1] == old_epoch
+
+    def test_empty_list(self):
+        assert rpm_sort([]) == []
+
+    def test_single_package(self):
+        pkg = self._pkg("5.14.0", "362.el9")
+        assert rpm_sort([pkg]) == [pkg]
+
+    def test_identical_packages(self):
+        pkg = self._pkg("5.14.0", "362.el9")
+        result = rpm_sort([pkg, pkg])
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# rpm_sort — dict input (ansible_facts.packages style)
+# ---------------------------------------------------------------------------
+
+class TestRpmSortDictInput:
+    """Test that rpm_sort accepts a full ansible_facts.packages dict."""
+
+    def test_multi_key_dict_sorted_by_name_then_evr(self):
+        """Passing a dict sorts by package name, then by EVR within each."""
+        packages = {
+            "kernel": [
+                {"name": "kernel", "epoch": 0, "version": "4.18.0",
+                 "release": "553.el8_10", "arch": "x86_64"},
+                {"name": "kernel", "epoch": 0, "version": "4.18.0",
+                 "release": "477.10.1.el8_8", "arch": "x86_64"},
+            ],
+            "glibc": [
+                {"name": "glibc", "epoch": 0, "version": "2.28",
+                 "release": "236.el8_9", "arch": "x86_64"},
+            ],
+        }
+        result = rpm_sort(packages)
+        assert len(result) == 3
+        assert result[0]["name"] == "glibc"
+        assert result[1]["name"] == "kernel"
+        assert result[1]["release"] == "477.10.1.el8_8"
+        assert result[2]["name"] == "kernel"
+        assert result[2]["release"] == "553.el8_10"
+
+    def test_single_key_dict(self):
+        """A dict with one key behaves like passing that key's list."""
+        packages = {
+            "kernel": [
+                {"name": "kernel", "epoch": 0, "version": "4.18.0",
+                 "release": "553.157.1.el8_10", "arch": "x86_64"},
+                {"name": "kernel", "epoch": 0, "version": "4.18.0",
+                 "release": "553.el8_10", "arch": "x86_64"},
+            ],
+        }
+        result = rpm_sort(packages)
+        assert len(result) == 2
+        assert result[0]["release"] == "553.el8_10"
+        assert result[1]["release"] == "553.157.1.el8_10"
+
+    def test_empty_dict(self):
+        """An empty dict returns an empty list."""
+        assert rpm_sort({}) == []

--- a/tests/units/.gitkeep
+++ b/tests/units/.gitkeep
@@ -1,3 +1,0 @@
-This is a placeholder file that only exists to keep the current
-directory in Git. It is safe to remove it once this directory contains
-the actual test files.


### PR DESCRIPTION
This PR fixes #265 by removing the `sort -Vr` command and replacing it with a custom module called `rpm_sort`, which handles RPM versioning properly.

Please let me know if there are better options to add this functionality by pulling the functionality from a different place. My thinking was to keep the dependencies as low as possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel remediation reliability by accurately identifying and sorting installed kernels.
  * Remediation now compares the latest installed kernel with the running kernel before updating the default and rebooting.
  * Improved handling of kernel version details, including release, architecture, and newer kernel updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->