### PR TITLE
ci(testing-farm): change the git_ref for testing farm tests

### DIFF
--- a/.github/workflows/testing-farm.yml
+++ b/.github/workflows/testing-farm.yml
@@ -1,9 +1,9 @@
 ---
 name: Testing Farm — On-demand tests
 on:
-  # Tests that run on issue_comment are run from the main branch.
-  # Changes to this workflow and to tmt plans and tests need to be merged to
-  # main first to appear in CI runs.
+  # Tests that run on issue_comment are run from the PR branch.
+  # Changes to the workflow file itself need to be merged to main first to
+  # appear in CI runs, but tmt plans and tests run from the PR branch.
   issue_comment:
     types:
       - created
@@ -262,7 +262,7 @@ jobs:
         uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1 # v4.3.1
         if: steps.platform_check.outputs.is_supported == 'true'
         with:
-          git_ref: main
+          git_ref: ${{ needs.prepare_vars.outputs.head_sha }}
           tmt_plan_filter: "tag:${{ matrix.test_scope }}_tests"
           pipeline_settings: '{ "type": "tmt-multihost" }'
           environment_settings: '{ "provisioning": { "tags": { "BusinessUnit": "ansible_collection_leapp" } } }'
@@ -272,7 +272,7 @@ jobs:
             SR_GITHUB_ORG=${{ github.repository_owner }};\
             SR_PR_NUM=${{ github.event.issue.number }};\
             SR_ARTIFACTS_DIR=${{ steps.set_vars.outputs.ARTIFACTS_DIR }};\
-            SR_TEST_LOCAL_CHANGES=false;\
+            SR_TEST_LOCAL_CHANGES=true;\
             SR_LSR_USER=${{ vars.SR_LSR_USER }};\
             RHEL_7_9_SERVER_REPO_URL=${{ secrets.RHEL_7_9_SERVER_REPO_URL }};\
             RHEL_7_9_EXTRAS_REPO_URL=${{ secrets.RHEL_7_9_EXTRAS_REPO_URL }};\


### PR DESCRIPTION
Change the git_ref for testing farm on-demand tests so that the tests introduced in a PR would be discovered in its CI.

In the original CI the tmt plans for on-demand tests were fetched from main since the tests were discovered under one entry. Currently, each test has its own tmt entry and thus this requires the tmt plans to be fetched from the PR branch.

The `SR_TEST_LOCAL_CHANGES` is set to `true` now to prevent additional clone of the repository on the controller node as the PR branch is already used by the tmt as well as the TF.

The workflow file is still taken from the main branch so I tried this in my fork which has this change already in main. The [PR#3](https://github.com/PeterMocary/infra.leapp/pull/3) has added a dummy test that is picked up in the CI of the PR.

This relates to the #420 which added a test that [was not discovered in CI run](https://github.com/redhat-cop/infra.leapp/actions/runs/32746849855). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified testing instructions for issue-comment-triggered test runs.
  * Documented that workflow changes must be merged before testing.
* **Bug Fixes**
  * Testing now runs against the pull request’s latest commit and supports testing local changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->